### PR TITLE
Fix absolutizing relative keys in partials

### DIFF
--- a/lib/i18n/tasks/base_task.rb
+++ b/lib/i18n/tasks/base_task.rb
@@ -96,7 +96,7 @@ module I18n
         # normalized path
         path = Pathname.new(File.expand_path path).relative_path_from(Pathname.new(Dir.pwd)).to_s
         # key prefix based on path
-        prefix = path.gsub(%r(app/views/|(\.[^/]+)*$), '').tr('/', '.')
+        prefix = path.gsub(%r(app/views/|(\.[^/]+)*$), '').tr('/', '.').gsub(%r(\._), '.')
         "#{prefix}#{key}"
       end
 


### PR DESCRIPTION
If I have a relative key defined in a partial like:

**app/views/layouts/_header.html.haml**

```
= t('.home')
```

And I have the key's value defined in a locale file like:

```
en:
  layouts:
    header:
      home: Home
```

The value displays as expected in the views, but when I run `rake i18n:missing` I get output of:

```
Missing keys and translations (68)
Legend: ✗ key missing, ∅ translation blank, = value equal to base locale; value in base locale

en    ✗      layouts._header.home
```

Substituting `._` for `.` in the `prefix` when it's created in the `absolutize_key` method solved this issue for me. 
