### PR TITLE
catch NoMethodError exception thrown by .try

### DIFF
--- a/lib/i18n/tasks/reports/terminal.rb
+++ b/lib/i18n/tasks/reports/terminal.rb
@@ -22,7 +22,11 @@ module I18n
                   base_value = ''
                 else
                   locale     = magenta rec[:locale]
-                  base_value = cyan rec[:base_value].try(:strip) || ''
+                  begin
+                    base_value = cyan rec[:base_value].try(:strip) || ''
+                  rescue
+                    base_value = cyan ''
+                  end
                 end
                 [{value: locale, alignment: :center},
                  {value: glyph, alignment: :center},


### PR DESCRIPTION
While running `rake i18n:missing`, an exception was thrown :

``` shell
** Invoke i18n:missing (first_time)
** Invoke i18n:setup (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute i18n:setup
** Execute i18n:missing
Missing translations (127) | i18n-tasks v0.2.11
Types: ✗ key missing, ∅ translation blank, = value same as base value
rake aborted!
undefined method `strip' for #<Array:0x007fdbf274e070>
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activesupport-3.2.16/lib/active_support/core_ext/object/try.rb:36:in `try'
/var/www/i18n-tasks/lib/i18n/tasks/reports/terminal.rb:25:in `block (2 levels) in missing_translations'
/var/www/i18n-tasks/lib/i18n/tasks/reports/terminal.rb:17:in `map'
/var/www/i18n-tasks/lib/i18n/tasks/reports/terminal.rb:17:in `block in missing_translations'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/terminal-table-1.4.5/lib/terminal-table/table.rb:210:in `yield_or_eval'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/terminal-table-1.4.5/lib/terminal-table/table.rb:17:in `initialize'
/var/www/i18n-tasks/lib/i18n/tasks/reports/terminal.rb:66:in `new'
/var/www/i18n-tasks/lib/i18n/tasks/reports/terminal.rb:66:in `print_table'
/var/www/i18n-tasks/lib/i18n/tasks/reports/terminal.rb:16:in `missing_translations'
/var/www/i18n-tasks/lib/tasks/i18n-tasks.rake:16:in `block (2 levels) in <top (required)>'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:236:in `call'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:236:in `block in execute'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:231:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:231:in `execute'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:175:in `block in invoke_with_call_chain'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/2.0.0/monitor.rb:211:in `mon_synchronize'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:168:in `invoke_with_call_chain'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/task.rb:161:in `invoke'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:149:in `invoke_task'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:106:in `block (2 levels) in top_level'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:106:in `each'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:106:in `block in top_level'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:115:in `run_with_threads'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:100:in `top_level'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:78:in `block in run'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:165:in `standard_exception_handling'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/lib/rake/application.rb:75:in `run'
/home/vagrant/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/rake-10.1.0/bin/rake:33:in `<top (required)>'
/home/vagrant/.rbenv/versions/2.0.0-p247/bin/rake:23:in `load'
/home/vagrant/.rbenv/versions/2.0.0-p247/bin/rake:23:in `<main>'
Tasks: TOP => i18n:missing
```

This pr fixes that exception.

Thanks
