### PR TITLE
Is 'activesupport' gem really required?

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rake'
   s.add_dependency 'erubis'
-  s.add_dependency 'activesupport'
   s.add_dependency 'easy_translate', '>= 0.4.0'
   s.add_dependency 'term-ansicolor'
   s.add_dependency 'terminal-table'

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -1,6 +1,4 @@
 module I18n::Tasks::Configuration
-  extend ::ActiveSupport::Concern
-
   # i18n-tasks config (defaults + config/i18n-tasks.yml)
   # @return [Hash{String => String,Hash,Array}]
   def config


### PR DESCRIPTION
I'm using `i18n-tasks` for my project (Parallels/vagrant-parallels#56) and I've noticed that it brings this dependency chain which I don't need: `activesupport -> minitest`

I could be wrong, but it seems to me that it isn't necessary to extend `I18n::Tasks::Configuration` by `ActiveSupport::Concern`.

I've tried to delete this and it is still working fine. So, do we really need for 'activesupport' gem dependency?
