### PR TITLE
Fixed a minimal typo in a comment

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -22,7 +22,7 @@ data:
   # key => file routes, matched top to bottom
   write:
     ## E.g., write devise and simple form keys to their respective files
-    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale.yml}']
+    # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
     # Catch-all
     - config/locales/%{locale}.yml
     # `i18n-tasks normalize -p` will force move the keys according to these rules


### PR DESCRIPTION
Just simply commenting in the suggested pattern for writing to devise and simple form caused an error due to a closing brace in the wrong place.
