### PR TITLE
test numeric value as input for issue #99

### DIFF
--- a/lib/i18n/tasks/google_translation.rb
+++ b/lib/i18n/tasks/google_translation.rb
@@ -60,6 +60,8 @@ Get the key at https://code.google.com/apis/console.')
           value.map { |v| dump_value v }
         when String
           replace_interpolations value
+        when Fixnum
+          value.to_s
         else
           value
       end
@@ -74,6 +76,8 @@ Get the key at https://code.google.com/apis/console.')
           restore_interpolations untranslated, each_translated.next
         when NilClass
           nil
+        when Fixnum
+          untranslated
         else
           each_translated.next
       end
@@ -81,6 +85,8 @@ Get the key at https://code.google.com/apis/console.')
 
     INTERPOLATION_KEY_RE  = /%\{[^}]+\}/.freeze
     UNTRANSLATABLE_STRING = 'zxzxzx'.freeze
+    OBJECT_STRING = 'zyzyzy'.freeze
+    OBJECT_STRING_REGEXP = /^zyzyzy/
 
     # 'hello, %{name}' => 'hello, <round-trippable string>'
     def replace_interpolations(value)

--- a/spec/google_translate_spec.rb
+++ b/spec/google_translate_spec.rb
@@ -6,6 +6,7 @@ describe 'Google Translation' do
   include I18n::Tasks::GoogleTranslation
 
   tests = [
+      numeric_value_test = ['numeric-key', 1, 1],
       nil_value_test = ['nil-value-key', nil, nil],
       text_test      = ['key', "Hello - %{user} O'neill!", "Hola - %{user} O'neill!"],
       html_test      = ['html-key.html', "Hello - <b>%{user} O'neill</b>", "Hola - <b>%{user} O'neill</b>"],
@@ -45,7 +46,8 @@ describe 'Google Translation' do
                     'hello'         => text_test[1],
                     'hello_html'    => html_test[1],
                     'array_key'     => array_test[1],
-                    'nil-value-key' => nil_value_test[1]
+                    'nil-value-key' => nil_value_test[1],
+                    'numeric-key' => numeric_value_test[1]
                 }
             })
             task.data[:es] = build_tree('es' => {
@@ -59,6 +61,7 @@ describe 'Google Translation' do
             expect(task.t('common.hello_html', 'es')).to eq(html_test[2])
             expect(task.t('common.array_key', 'es')).to eq(array_test[2])
             expect(task.t('nil-value-key', 'es')).to eq(nil_value_test[2])
+            expect(task.t('common.numeric-key', 'es')).to eq(numeric_value_test[2])
             expect(task.t('common.a', 'es')).to eq('λ')
           end
         end


### PR DESCRIPTION
Try to add a test to demonstrate and possibly fix issue #99. The test fails but I don't understand why...

```
$ rspec
.....................F[deprecated] I18n.enforce_available_locales will default to true in the future. If you really want to skip validation of your locale you can set I18n.enforce_available_locales = false to avoid this message.
Translated 5 keys
+--------+----------------------+-------------------------------+
| Locale | Key                  | Value                         |
+--------+----------------------+-------------------------------+
|   es   | common.array_key     | ["Hola.", nil, "", "Adiós."]  |
|   es   | common.hello         | Hola - %{user} O'neill!       |
|   es   | common.hello_html    | Hola - <b>%{user} O'neill</b> |
|   es   | common.nil-value-key |                               |
|   es   | common.numeric-key   | 1                             |
+--------+----------------------+-------------------------------+
.................................................................................

Failures:

  1) Google Translation real world test #google_translate_list works with ["numeric-key", "nil-value-key", "key", "html-key.html", "array-key"]
     Failure/Error: expect(translations).to eq(tests.map { |t| [t[0], t[2]] })

       expected: [["numeric-key", 1], ["nil-value-key", nil], ["key", "Hola - %{user} O'neill!"], ["html-key.html", "Hola - <b>%{user} O'neill</b>"], ["array-key", ["Hola.", nil, "", "Adiós."]]]
            got: [["numeric-key", 1], ["nil-value-key", nil], ["key", "1"], ["html-key.html", "Hola - <b>%{user} O'neill</b>"], ["array-key", ["Hola - zxzxzx O'neill!", nil, "Hola.", ""]]]

       (compared using ==)
     # ./spec/google_translate_spec.rb:25:in `block (4 levels) in <top (required)>'

Finished in 6.12 seconds (files took 0.34055 seconds to load)
103 examples, 1 failure

Failed examples:

rspec ./spec/google_translate_spec.rb:21 # Google Translation real world test #google_translate_list works with ["numeric-key", "nil-value-key", "key", "html-key.html", "array-key"]
```
