### PR TITLE
Remove warning message

### DIFF
--- a/lib/i18n/tasks/scanners/base_scanner.rb
+++ b/lib/i18n/tasks/scanners/base_scanner.rb
@@ -120,7 +120,7 @@ module I18n::Tasks::Scanners
     VALID_KEY_RE = /^(#{VALID_KEY_CHARS}|[\#{@}])+$/
 
     def valid_key?(key, strict = false)
-      return false if @key_filter && @key_filter_pattern !~ key
+      return false if key_filter && @key_filter_pattern !~ key
       if strict
         key =~ VALID_KEY_RE_STRICT && !key.end_with?('.')
       else


### PR DESCRIPTION
When running the tests there is a warning message:

```
lib/i18n/tasks/scanners/base_scanner.rb:123: warning: instance variable
@key_filter not initialized
```

In order to remove it:
- Use `key_filter` method instead of the instance variable `@key_filter`
