### PR TITLE
Lines in HAML that start with # are skipped

### DIFF
--- a/spec/used_keys_spec.rb
+++ b/spec/used_keys_spec.rb
@@ -3,14 +3,18 @@ require 'spec_helper'
 
 describe 'UsedKeys' do
   let!(:task) { I18n::Tasks::BaseTask.new }
-
-  around do |ex|
-    task.config[:search] = {paths: ['a.html.slim']}
-    TestCodebase.setup('a.html.slim' => <<-SLIM)
+  let(:file_name) { 'a.html.slim' }
+  let(:file_content) do
+    <<-SLIM
 div = t 'a'
   p = t 'a'
 h1 = t 'b'
     SLIM
+  end
+
+  around do |ex|
+    task.config[:search] = {paths: [file_name]}
+    TestCodebase.setup(file_name => file_content)
     TestCodebase.in_test_app_dir { ex.run }
     TestCodebase.teardown
   end
@@ -44,5 +48,27 @@ h1 = t 'b'
         source_occurrences:
             [{pos: 29, line_num: 3, line_pos: 6, line: "h1 = t 'b'", src_path: 'a.html.slim'}]
     )
+  end
+
+  describe 'when input is haml' do
+    let(:file_name) { 'a.html.haml' }
+    let(:file_content) do
+      <<-HAML
+#first{ title: t('a') }
+.second{ title: t('a') }
+      HAML
+    end
+
+    it '#used_keys(source_occurences: true)' do
+      used_keys = task.used_tree(source_occurrences: true)
+      expect(used_keys.size).to eq 2
+      expect_node_key_data(
+          used_keys.leaves.first,
+          'a',
+          source_occurrences:
+              [{pos: 15, line_num: 1, line_pos: 16, line: "#first{ title: t('a') }", src_path: 'a.html.haml'},
+               {pos: 40, line_num: 2, line_pos: 17, line: ".second{ title: t('a') }", src_path: 'a.html.haml'}]
+      )
+    end
   end
 end


### PR DESCRIPTION
In HAML, lines can start with `#` as that signifies an HTML id, like:

``` haml
#my-id{ title: t('translation_key') }
```

This pull request just adds a spec that fails.  Would be happy to contribute though if there are any thoughts about how to address this (or whether it should be addressed at all).
