### PR TITLE
Tidy up the spec template indentation, use let(:unused_keys).

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -8,11 +8,11 @@ describe 'I18n' do
 
   it 'does not have missing keys' do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
   it 'does not have unused keys' do
-    expect(i18n.unused_keys).to be_empty,
-                                "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+    expect(unused_keys).to be_empty,
+      "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
   end
 end

--- a/templates/rspec/i18n_spec.rb
+++ b/templates/rspec/i18n_spec.rb
@@ -8,11 +8,11 @@ describe 'I18n' do
 
   it 'does not have missing keys' do
     expect(missing_keys).to be_empty,
-                            "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+      "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
   it 'does not have unused keys' do
-    expect(i18n.unused_keys).to be_empty,
-                                "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+    expect(unused_keys).to be_empty,
+      "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
   end
 end


### PR DESCRIPTION
Minor tweaks for those of us who use the spec template =)
