### PR TITLE
Fix the dependency on slop to be > 3.5 but lower than 4.0 

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -39,7 +39,7 @@ TEXT
   s.add_dependency 'term-ansicolor'
   s.add_dependency 'terminal-table'
   s.add_dependency 'highline'
-  s.add_dependency 'slop', '>= 3.5.0'
+  s.add_dependency 'slop', '~> 3.5'
   s.add_dependency 'i18n'
   s.add_development_dependency 'axlsx', '~> 2.0'
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
because the slop project has a hard dependency on ruby 2.0.0+ for version 4.0 and up. The alternative to this would be to state that i18n-tasks only supports ruby 2.0.0+ as well