### PR TITLE
Add support for the 'it' gem

### DIFF
--- a/lib/i18n/tasks/scanners/pattern_scanner.rb
+++ b/lib/i18n/tasks/scanners/pattern_scanner.rb
@@ -70,7 +70,7 @@ module I18n::Tasks::Scanners
     end
 
     def translate_call_re
-      /(?<=^|[^\w'\-])t(?:ranslate)?/
+      /(?<=^|[^\w'\-])i?t(?:ranslate)?/
     end
 
     # Match literals:

--- a/spec/pattern_scanner_spec.rb
+++ b/spec/pattern_scanner_spec.rb
@@ -37,13 +37,28 @@ describe 'Pattern Scanner' do
       "t('a.b', :arg => val)",
       "t('a.b', arg: val)",
       "t :a_b",
+      "t :a_b",
       "t :'a.b'",
       't :"a.b"',
       "t(:ab)",
       "t(:'a.b')",
       't(:"a.b")',
       'I18n.t("a.b")',
-      'I18n.translate("a.b")'
+      'I18n.translate("a.b")',
+      'it(".a.b")',
+      'it "a.b"',
+      "it 'a.b'",
+      'it("a.b")',
+      "it('a.b')",
+      "it('a.b', :arg => val)",
+      "it('a.b', arg: val)",
+      "it :a_b",
+      "it :a_b",
+      "it :'a.b'",
+      'it :"a.b"',
+      "it(:ab)",
+      "it(:'a.b')",
+      'it(:"a.b")'
     ].each do |string|
       it "matches #{string}" do
         expect(pattern).to match string


### PR DESCRIPTION
See https://github.com/iGEL/it for details of the gem.

This change simply tweaks the parser slightly to pick up things like:

    <%= it :your_privacy_is_important, privacy_link: It.link(privacy_url()) %>

...so that it doesn't report erroneous unused translations.

Includes updated specs.
