### PR TITLE
Handle relative keys in controllers whose name consist of multiple words

### DIFF
--- a/lib/i18n/tasks/scanners/relative_keys.rb
+++ b/lib/i18n/tasks/scanners/relative_keys.rb
@@ -42,7 +42,8 @@ module I18n
           file_name = normalized_path.gsub(%r(#{path_root(normalized_path, roots)}/|(\.[^/]+)*$), '')
 
           if options[:closest_method].present?
-            "#{file_name.split('_').first}.#{options[:closest_method]}".tr('/', '.')
+            controller_name = file_name.sub(/_controller$/, '')
+            "#{controller_name}.#{options[:closest_method]}".tr('/', '.')
           else
             file_name.tr('/', '.').gsub(%r(\._), '.')
           end

--- a/spec/relative_keys_spec.rb
+++ b/spec/relative_keys_spec.rb
@@ -29,6 +29,19 @@ describe 'Relative keys' do
         expect(key).to eq('users.create.success')
       end
 
+      context 'multiple words in controller name' do
+        it 'works' do
+          key = scanner.absolutize_key(
+            '.success',
+            'app/controllers/admin_users_controller.rb',
+            %w(app/controllers),
+            'create'
+          )
+
+          expect(key).to eq('admin_users.create.success')
+        end
+      end
+
       context 'nested in module' do
         it 'works' do
           key = scanner.absolutize_key(


### PR DESCRIPTION
Currently relative keys in `app/controllers/admin_users_controller.rb` are resolved as `admin.KEY`.

With this fix they'll be resolved as `admin_users.KEY` correctly.