### PR TITLE
Don't require spec_helper where you don't need to.

### DIFF
--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'i18n/tasks'
 
 describe 'I18n' do

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-require 'spec_helper'
+
 describe 'README.md' do
   let(:readme) { File.read('README.md', encoding: 'UTF-8') }
   it 'has valid YAML in ```yaml blocks' do

--- a/templates/rspec/i18n_spec.rb
+++ b/templates/rspec/i18n_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'i18n/tasks'
 
 describe 'I18n' do


### PR DESCRIPTION
I was updating my copy of the `I81n` spec and realized
that `require`-ing `spec_helper` wasn't needed to run the spec in isolation.
While loading the `spec_helper` doesn't add much overhead to this project,
requiring `spec_helper` adds a ton of load time for many bloated projects.

Hope this helps!