### PR TITLE
feat(siblings): do not mark entries as missing if keys contain periods

### DIFF
--- a/lib/i18n/tasks/data/tree/siblings.rb
+++ b/lib/i18n/tasks/data/tree/siblings.rb
@@ -55,7 +55,7 @@ module I18n::Tasks::Data::Tree
       if rest && node
         node = node.children.try(:get, rest)
       end
-      node
+      node || key_to_node[full_key]
     end
 
     alias [] get

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'i18n-tasks' do
               out, err = clean_coverage_logging[out], clean_coverage_logging[err]
               expect(status).to be_success
               expect(out).to be_empty
-              expect(err).to start_with('Usage: i18n-tasks [command] [options]')
+              expect(err).to include('Usage: i18n-tasks [command] [options]')
               expect(err).to include('Available commands', 'add-missing')
               # a task from a plugin
               expect(err).to include('greet')


### PR DESCRIPTION
As subject. I have a bunch of files that have periods in keys, like:

```
'GEORGIA A: Literature self taught': 'GEORGIANO A Literatura autodidacta'
```

they get reported as missing without this patch.
