### PR TITLE
Adds ':' to VALID_KEY_CHARS for ruby_key_literals.

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -19,7 +19,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!;À-ž])/
+    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž])/
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/
 
     def valid_key?(key)

--- a/spec/fixtures/app/views/index.html.slim
+++ b/spec/fixtures/app/views/index.html.slim
@@ -34,3 +34,5 @@ p = Spree.t 'not_a_key'
 = t 'reference-ok-plain'
 = t 'reference-ok-nested.a'
 = t 'reference-missing-target.a'
+
+p = t 'missing_key_ending_in_colon.key:'

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'i18n-tasks' do
         missing_symbol.key_two
         missing_symbol.key_three
         missing-key-with-a-dash.key
+        missing_key_ending_in_colon.key:
         missing-key-question?.key
         fn_comment
         events.show.success

--- a/spec/support/capture_std.rb
+++ b/spec/support/capture_std.rb
@@ -1,6 +1,22 @@
 # frozen_string_literal: true
-require 'active_support/core_ext/kernel/reporting'
+
+# This is necessary because Rails 5 removed the Kernel extension of
+# that added `#silence_stream` and moved it to their testing set of
+# libraries. Therefore, I'm including this here. Technically any
+# testing will conceivably install version 5 meaning the include is
+# necessary. However, this allows us to clearly be compliant with
+# both rails 4 and 5 which the gemspec supports.
+require 'active_support/gem_version'
+
+if ActiveSupport::VERSION::MAJOR == 5
+  require 'active_support/testing/stream'
+else
+  require 'active_support/core_ext/kernel/reporting'
+end
+
 module CaptureStd
+  include ActiveSupport::Testing::Stream if defined?(ActiveSupport::Testing::Stream)
+
   def capture_stderr
     err, $stderr = $stderr, StringIO.new
     yield

--- a/spec/support/capture_std.rb
+++ b/spec/support/capture_std.rb
@@ -8,10 +8,10 @@
 # both rails 4 and 5 which the gemspec supports.
 require 'active_support/gem_version'
 
-if ActiveSupport::VERSION::MAJOR == 5
-  require 'active_support/testing/stream'
-else
+if ActiveSupport::VERSION::MAJOR == 4
   require 'active_support/core_ext/kernel/reporting'
+else
+  require 'active_support/testing/stream'
 end
 
 module CaptureStd

--- a/spec/support/i18n_tasks_output_matcher.rb
+++ b/spec/support/i18n_tasks_output_matcher.rb
@@ -15,7 +15,7 @@ RSpec::Matchers.define :be_i18n_keys do |expected|
     key_col = 1
     actual.map { |row|
       key = [row[locale_col], row[key_col]].map(&:presence).compact.join('.')
-      key = key[0..-2] if key.end_with?(':')
+      key = key[0..-2] if key.end_with?('.:')
       key = key.sub(/\((?:ref|resolved ref|ref key)\) /, '')
       key
     }.compact


### PR DESCRIPTION
Aims to fix #207 

Passing build: https://travis-ci.org/jon2992/i18n-tasks/builds/172334674

[This line in i18n_tasks_output_matcher](https://github.com/glebm/i18n-tasks/compare/master...jon2992:allow-colon-in-key?expand=1#diff-a633a3a22ee3798d2192bf9cfe719725R18) was adjusted to allow non-globbing keys to print out correctly if they end in a colon. I left a comment explaining my changes in `capture_std.rb`. Maybe it's just my system, but Travis also failed for that reason. It made sense to met that the tests should support ActiveSupport 4 and 5 given the support of the gem itself is that.