### PR TITLE
Update readline dependency to >= 1.6.18

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -39,7 +39,7 @@ TEXT
   s.add_dependency 'ast', '>= 2.1.0'
   s.add_dependency 'easy_translate', '>= 0.5.0'
   s.add_dependency 'erubis'
-  s.add_dependency 'highline', '>= 1.7.3'
+  s.add_dependency 'highline', '>= 1.6.18'
   s.add_dependency 'i18n'
   s.add_dependency 'parser', '>= 2.2.3.0'
   s.add_dependency 'rainbow', '~> 2.2'


### PR DESCRIPTION
Following the discussion on https://github.com/glebm/i18n-tasks/issues/210 i'd like to lower the readline required version.
I'm doing this because i want to include some i18n-tasks tasks on `solidus_i18n` and to support all the Solidus versions. 
Some of them are pretty old and had a hard dependency on readline 1.6 for some weird reasons.

Thank you ❤️ 