### PR TITLE
Fixed pattern with key as variable for pattern with scope scanner

### DIFF
--- a/lib/i18n/tasks/scanners/pattern_with_scope_scanner.rb
+++ b/lib/i18n/tasks/scanners/pattern_with_scope_scanner.rb
@@ -32,6 +32,12 @@ module I18n::Tasks::Scanners
       end
     end
 
+    # parse expressions with literals and variable
+    alias literal_re_orig literal_re
+    def literal_re
+      /(?: (?: #{literal_re_orig} ) | #{variable_re} )/x
+    end
+
     # strip literals, convert expressions to #{interpolations}
     def strip_literal(val)
       if val =~ /\A\w/
@@ -56,6 +62,12 @@ module I18n::Tasks::Scanners
       /[\w():"'.\s]+/x
     end
 
+    # match variable key
+    # e.g: t(key, scope: 'scope') => t('scope.#{key}')
+    def variable_re
+      /\w+/
+    end
+
     # extract literal or array of literals
     # returns nil on any other input
     # rubocop:disable Metrics/CyclomaticComplexity,Metrics/MethodLength,Metrics/PerceivedComplexity
@@ -65,7 +77,7 @@ module I18n::Tasks::Scanners
       acc = []
       consume_literal = proc do
         acc_str = acc.join
-        if acc_str =~ literal_re
+        if acc_str =~ literal_re_orig
           literals << strip_literal(acc_str)
           acc = []
         else

--- a/spec/pattern_with_scope_scanner_spec.rb
+++ b/spec/pattern_with_scope_scanner_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe 'PatternWithScopeScanner' do
 
       stub_source scanner, '= t :key, :scope => :scope, default: "Default"'
       expect(scanner.keys.map(&:key)).to eq(['scope.key'])
+
+      stub_source scanner, '= t key, scope: "scope"'
+      expect(scanner.keys.map(&:key)).to eq(['scope.#{key}'])
     end
 
     it 'matches an array of literals scope' do
@@ -46,6 +49,9 @@ RSpec.describe 'PatternWithScopeScanner' do
       expect(scanner.keys.map(&:key)).to eq([])
 
       stub_source scanner, '= t :key, scope: (a)'
+      expect(scanner.keys.map(&:key)).to eq([])
+
+      stub_source scanner, '= t key, scope: (a)'
       expect(scanner.keys.map(&:key)).to eq([])
     end
 


### PR DESCRIPTION
Hi @glebm ,

I hope this find you well.

This https://github.com/glebm/i18n-tasks/commit/8e6b327d169901f689d56b9e79748d0bea236ebe broke our build.

With that changes, you are breaking the scenario below:

```
t(variable, scope: 'scope')
``` 

This will support both world, 

- https://github.com/glebm/i18n-tasks/issues/213
- And key as variable

Please have a look.

Thanks.