### PR TITLE
Remove explicit ast dependency

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -36,7 +36,6 @@ TEXT
   s.require_paths = ['lib']
 
   s.add_dependency 'activesupport', '>= 4.0.2'
-  s.add_dependency 'ast', '>= 2.1.0'
   s.add_dependency 'easy_translate', '>= 0.5.0'
   s.add_dependency 'erubi'
   s.add_dependency 'highline', '>= 1.7.3'


### PR DESCRIPTION
Since `parser` gem specifies `ast` as a dependency in its gemspec, you do not have to add your own `ast` dependence in a gemspec of `i18n-tasks` (like Rubocop has only `parser` in its gemspec dependencies) .

I think this change reduces dependence complexity and make maintenance easier. How does this sound to you?