### PR TITLE
Locale data from dependencies: `data.external`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## v0.9.19 (not yet released)
 
+Adds a new configuration setting, `data.external`, for locale data from external dependencies (e.g. gems).
+This locale data is never considered unused, and is never modified by i18n-tasks.
+[#264](https://github.com/glebm/i18n-tasks/issues/264)
+
 Fixes support for calls such as `t @instance_variable, scope: :static_scope` in the non-AST scanner.
 [#1d2c6d0c](https://github.com/glebm/i18n-tasks/commit/1d2c6d0cb7ee20a8db68c52e33ec3c2a382633e6)
 

--- a/lib/i18n/tasks/data.rb
+++ b/lib/i18n/tasks/data.rb
@@ -59,6 +59,10 @@ module I18n::Tasks
       !t(key, locale).nil?
     end
 
+    def external_key?(key, locale = base_locale)
+      data.external(locale)[locale.to_s][key]
+    end
+
     # Normalize all the locale data in the store (by writing to the store).
     #
     # @param [Array<String>] locales locales to normalize. Default: all.

--- a/lib/i18n/tasks/data/file_system_base.rb
+++ b/lib/i18n/tasks/data/file_system_base.rb
@@ -42,6 +42,14 @@ module I18n::Tasks
 
       alias [] get
 
+      # @param [String, Symbol] locale
+      # @return [::I18n::Tasks::Data::Siblings]
+      def external(locale)
+        locale = locale.to_s
+        @external ||= {}
+        @external[locale] ||= read_locale(locale, paths: config[:external])
+      end
+
       # set locale tree
       # @param [String, Symbol] locale
       # @param [::I18n::Tasks::Data::Siblings] tree

--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -85,7 +85,7 @@ module I18n::Tasks
     end
 
     def locale_key_missing?(locale, key)
-      !key_value?(key, locale) && !ignore_key?(key, :missing)
+      !key_value?(key, locale) && !external_key?(key) && !ignore_key?(key, :missing)
     end
 
     # @param [::I18n::Tasks::Data::Tree::Siblings] forest

--- a/spec/fixtures/app/views/usages.html.slim
+++ b/spec/fixtures/app/views/usages.html.slim
@@ -1,2 +1,4 @@
 p = t 'used.a'
 b = t 'used.a'
+
+p = t 'external.used'

--- a/spec/fixtures/config/i18n-tasks.yml.erb
+++ b/spec/fixtures/config/i18n-tasks.yml.erb
@@ -15,6 +15,8 @@ data:
     - ['devise.*', 'config/locales/devise.%{locale}.yml']
     # default catch-all (same as ['*', 'config/locales/%{locale}.yml'])
     - 'config/locales/%{locale}.yml'
+  external:
+    - 'config/locales/external/%{locale}.yml'
   yaml:
     write:
       line_width: -1

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -363,6 +363,10 @@ resolved_reference_target.a (resolved ref)
     fs = fixtures_contents.merge(
       'config/locales/en.yml' => { 'en' => en_data }.to_yaml,
       'config/locales/es.yml' => { 'es' => es_data }.to_yaml,
+      'config/locales/external/en.yml' =>
+          { 'en' => { 'external' => { 'used' => 'EN_TEXT', 'unused' => 'EN_TEXT' } } }.to_yaml,
+      'config/locales/external/es.yml' =>
+          { 'es' => { 'external' => { 'used' => 'ES_TEXT', 'unused' => 'ES_TEXT' } } }.to_yaml,
       'config/locales/old_devise.en.yml' => { 'en' => { 'devise' => { 'a' => 'EN_TEXT' } } }.to_yaml,
       'config/locales/old_devise.es.yml' => { 'es' => { 'devise' => { 'a' => 'ES_TEXT' } } }.to_yaml,
       'config/locales/unused.en.yml' => { 'en' => { 'unused' => { 'file' => 'EN_TEXT' } } }.to_yaml,

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -19,8 +19,6 @@ data:
     # - config/locales/%{locale}.yml
     ## More files:
     # - config/locales/**/*.%{locale}.yml
-    ## Another gem (replace %#= with %=):
-    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
 
   # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
   # `i18n-tasks normalize -p` will force move the keys according to these rules
@@ -29,6 +27,12 @@ data:
     # - ['{devise, simple_form}.*', 'config/locales/\1.%{locale}.yml']
     ## Catch-all default:
     # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+    ## Example (replace %#= with %=):
+    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router


### PR DESCRIPTION
Adds a new configuration setting, `data.external`, for locale data from dependencies.

Locale data from dependencies is never considered unused and we never
modify it.

Fixes #264 

@vsakarov PTAL