### PR TITLE
Change rainbow version lock in gemspec from ~>2.2 to ~>2.2.2

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -42,7 +42,7 @@ TEXT
   s.add_dependency 'highline', '>= 1.7.3'
   s.add_dependency 'i18n'
   s.add_dependency 'parser', '>= 2.2.3.0'
-  s.add_dependency 'rainbow', '~> 2.2'
+  s.add_dependency 'rainbow', '~> 2.2.2'
   s.add_dependency 'terminal-table', '>= 1.5.1'
   s.add_development_dependency 'axlsx', '~> 2.0'
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
The new Rubocop version (`0.51.0`) requires `rainbow (>= 2.2.2, < 3.0)`. 
When trying to use the new rubocop in application Bundler is complaining about incompatibility in versions
`i18n-tasks` requiring `~> 2.2` versus `rubocop` requiring `>= 2.2.2`