### PR TITLE
Allow missing type parameters to work with cli

### DIFF
--- a/lib/i18n/tasks/command/commands/missing.rb
+++ b/lib/i18n/tasks/command/commands/missing.rb
@@ -28,7 +28,7 @@ module I18n::Tasks
             args: %i[locales out_format missing_types]
 
         def missing(opt = {})
-          forest = i18n.missing_keys(opt.slice(:locales, :base_locale, :missing_types))
+          forest = i18n.missing_keys(opt.slice(:locales, :base_locale, :types))
           print_forest forest, opt, :missing_keys
           :exit_1 unless forest.empty?
         end

--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -16,7 +16,7 @@ module I18n::Tasks
       MissingKeys.missing_keys_types
     end
 
-    # @param types [:missing_used, :missing_diff] all if `nil`.
+    # @param types [:used, :diff] all if `nil`.
     # @return [Siblings]
     def missing_keys(locales: nil, types: nil, base_locale: nil)
       locales ||= self.locales

--- a/spec/commands/missing_commands_spec.rb
+++ b/spec/commands/missing_commands_spec.rb
@@ -5,21 +5,40 @@ require 'spec_helper'
 RSpec.describe 'Missing commands' do
   delegate :run_cmd, to: :TestCodebase
 
+  let(:missing_keys) { { 'a' => 'A', 'ref' => :ref } }
+  around do |ex|
+    TestCodebase.setup(
+      'config/i18n-tasks.yml' => { base_locale: 'en', locales: %w[es fr] }.to_yaml,
+      'config/locales/es.yml' => { 'es' => missing_keys }.to_yaml
+    )
+    TestCodebase.in_test_app_dir { ex.call }
+    TestCodebase.teardown
+  end
+
   describe '#add_missing' do
     describe 'adds the missing keys to base locale first, then to other locales' do
-      around do |ex|
-        TestCodebase.setup(
-          'config/i18n-tasks.yml' => { base_locale: 'en', locales: %w[es fr] }.to_yaml,
-          'config/locales/es.yml' => { 'es' => { 'a' => 'A', 'ref' => :ref } }.to_yaml
-        )
-        TestCodebase.in_test_app_dir { ex.call }
-        TestCodebase.teardown
-      end
-
       it 'with -v argument' do
         run_cmd 'add-missing', '-vTRME'
-        expect(YAML.load_file('config/locales/en.yml')).to eq('en' => { 'a' => 'TRME', 'ref' => :ref })
-        expect(YAML.load_file('config/locales/fr.yml')).to eq('fr' => { 'a' => 'TRME', 'ref' => :ref })
+        created_keys = missing_keys.dup
+        created_keys['a'] = 'TRME'
+        expect(YAML.load_file('config/locales/en.yml')).to eq('en' => created_keys)
+        expect(YAML.load_file('config/locales/fr.yml')).to eq('fr' => created_keys)
+      end
+    end
+  end
+
+  describe '#missing' do
+    describe 'returns missing keys' do
+      it 'with -t diff argument' do
+        expect(YAML.load(run_cmd 'missing', '-tdiff', '-fyaml')).to eq({ 'en' => missing_keys })
+      end
+
+      it 'with -t used argument' do
+        expect(YAML.load(run_cmd 'missing', '-tused', '-fyaml')).to eq({})
+      end
+
+      it 'with invalid -t argument' do
+        expect{run_cmd 'missing', '-tinvalid'}.to raise_error(I18n::Tasks::CommandError)
       end
     end
   end

--- a/spec/commands/missing_commands_spec.rb
+++ b/spec/commands/missing_commands_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe 'Missing commands' do
   describe '#missing' do
     describe 'returns missing keys' do
       it 'with -t diff argument' do
-        expect(YAML.load(run_cmd 'missing', '-tdiff', '-fyaml')).to eq({ 'en' => missing_keys })
+        expect(YAML.load(run_cmd('missing', '-tdiff', '-fyaml'))).to eq('en' => missing_keys)
       end
 
       it 'with -t used argument' do
-        expect(YAML.load(run_cmd 'missing', '-tused', '-fyaml')).to eq({})
+        expect(YAML.load(run_cmd('missing', '-tused', '-fyaml'))).to eq({})
       end
 
       it 'with invalid -t argument' do
-        expect{run_cmd 'missing', '-tinvalid'}.to raise_error(I18n::Tasks::CommandError)
+        expect { run_cmd 'missing', '-tinvalid' }.to raise_error(I18n::Tasks::CommandError)
       end
     end
   end


### PR DESCRIPTION
`i18n-tasks missing -tdiff` was ignoring the type field