### PR TITLE
Update the easy_translate to v0.5.1

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -37,7 +37,7 @@ TEXT
 
   s.add_dependency 'activesupport', '>= 4.0.2'
   s.add_dependency 'ast', '>= 2.1.0'
-  s.add_dependency 'easy_translate', '>= 0.5.0'
+  s.add_dependency 'easy_translate', '>= 0.5.1'
   s.add_dependency 'erubi'
   s.add_dependency 'highline', '>= 1.7.3'
   s.add_dependency 'i18n'


### PR DESCRIPTION
It has:
* Add license to gemspec (MIT)
* Update googleapi hostname to support premium (NMT)
* Remove json gem dependency

Details:
https://github.com/seejohnrun/easy_translate/compare/v0.5.0...v0.5.1

* * *

I particularly want to get rid the dependency on JSON gem.

> All modern Rubies ship JSON as part of stdlib. Using the gem actually hurts multi-platform support due to build difficulties on Windows.

Cite from: <https://github.com/rails/rails/commit/f3433f7c>
