### PR TITLE
Remove invalid gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ capybara-*.html
 /public/system/*
 /coverage/
 /spec/tmp/*
-**.orig
 rerun.txt
 pickle-email-*.html
 *.gem


### PR DESCRIPTION
Sometimes when I use [rigrep](https://github.com/BurntSushi/ripgrep) on a folder including my `i18n-tasks` clone, I get the following warning:

```
../../i18n-tasks/.gitignore: line 14: error parsing glob '**.orig': invalid use of **; must be one path component
```

Maybe this is not a valid ignore expression?