### PR TITLE
Command eq-base returns an error if any key is having the same value.

### DIFF
--- a/lib/i18n/tasks/command/commands/eq_base.rb
+++ b/lib/i18n/tasks/command/commands/eq_base.rb
@@ -12,7 +12,9 @@ module I18n::Tasks
             args: %i[locales out_format]
 
         def eq_base(opt = {})
-          print_forest i18n.eq_base_keys(opt), opt, :eq_base_keys
+          forest = i18n.eq_base_keys(opt)
+          print_forest forest, opt, :eq_base_keys
+          :exit_1 unless forest.empty?
         end
       end
     end


### PR DESCRIPTION
This would allow us to make this a blocking part of our CI.