### PR TITLE
Translation-missing: fix class scope at boot when no API key provided

### DIFF
--- a/lib/i18n/tasks/translators/google_translator.rb
+++ b/lib/i18n/tasks/translators/google_translator.rb
@@ -59,7 +59,7 @@ module I18n::Tasks::Translators
           )
           key ||= translation_config[:api_key]
         end
-        fail CommandError, I18n.t('i18n_tasks.google_translate.errors.no_api_key') if key.blank?
+        fail ::I18n::Tasks::CommandError, I18n.t('i18n_tasks.google_translate.errors.no_api_key') if key.blank?
         key
       end
     end


### PR DESCRIPTION
Using the same syntax as the one [line 11](https://github.com/glebm/i18n-tasks/blob/master/lib/i18n/tasks/translators/google_translator.rb#L11) fix the problem.

```
> i18n-tasks translate-missing
bundler: failed to load command: i18n-tasks (/Users/thomas/.rbenv/versions/2.5.1/bin/i18n-tasks)
NameError: uninitialized constant I18n::Tasks::Translators::GoogleTranslator::CommandError
Did you mean?  I18n::Tasks::CommandError
  /Users/thomas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/i18n-tasks-0.9.25/lib/i18n/tasks/translators/google_translator.rb:62:in `api_key'
  /Users/thomas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/i18n-tasks-0.9.25/lib/i18n/tasks/translators/google_translator.rb:24:in `options_for_translate_values'
  /Users/thomas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/i18n-tasks-0.9.25/lib/i18n/tasks/translators/base_translator.rb:43:in `fetch_translations'
  /Users/thomas/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/i18n-tasks-0.9.25/lib/i18n/tasks/translators/base_translator.rb:33:in `block in translate_pairs'
[...]
```

With the fix
```
i18n-tasks: Set Google API key via GOOGLE_TRANSLATE_API_KEY environment variable or translation.google_translate_api_key in config/i18n-tasks.yml. Get the key at https://code.google.com/apis/console.
```