### PR TITLE
Eq-base: returned value

### DIFF
--- a/lib/i18n/tasks/command/commands/eq_base.rb
+++ b/lib/i18n/tasks/command/commands/eq_base.rb
@@ -12,7 +12,9 @@ module I18n::Tasks
             args: %i[locales out_format]
 
         def eq_base(opt = {})
-          print_forest i18n.eq_base_keys(opt), opt, :eq_base_keys
+          forest = i18n.eq_base_keys(opt)
+          print_forest forest, opt, :eq_base_keys
+          :exit_1 unless forest.empty?
         end
       end
     end


### PR DESCRIPTION
Return 1 on error/empty list.

Fix #306 

```
> bundle exec i18n-tasks eq-base
Same value as en (1) | i18n-tasks v0.9.25
+--------+-----------+-------+
| Locale | Key       | Value |
+--------+-----------+-------+
|   ja   | fund.isin | ISIN  |
+--------+-----------+-------+
> echo $?
1
> bundle exec i18n-tasks eq-base
No translations are the same as base value
> echo $?
0
```