### PR TITLE
Do not consider a plural node if it only has "other" with no count

### DIFF
--- a/lib/i18n/tasks/plural_keys.rb
+++ b/lib/i18n/tasks/plural_keys.rb
@@ -46,7 +46,12 @@ module I18n::Tasks::PluralKeys
   end
 
   def plural_forms?(s)
+    return false if non_plural_other?(s)
     s.present? && s.all? { |node| node.leaf? && plural_suffix?(node.key) }
+  end
+
+  def non_plural_other?(s)
+    s.size == 1 && s.first.leaf? && s.first.key == 'other' && !s.first.value.include?('%{count}')
   end
 
   def plural_suffix?(key)

--- a/lib/i18n/tasks/plural_keys.rb
+++ b/lib/i18n/tasks/plural_keys.rb
@@ -51,7 +51,7 @@ module I18n::Tasks::PluralKeys
   end
 
   def non_plural_other?(s)
-    s.size == 1 && s.first.leaf? && s.first.key == 'other' && !s.first.value.include?('%{count}')
+    s.size == 1 && s.first.leaf? && (!s.first.value.is_a?(String) || !s.first.value.include?('%{count}'))
   end
 
   def plural_suffix?(key)


### PR DESCRIPTION
Fix #310