### PR TITLE
Update README and post installation instructions message

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ cp $(i18n-tasks gem-path)/templates/minitest/i18n_test.rb test/
 
 ## Usage
 
-Run `i18n-tasks` to get the list of all the tasks with short descriptions.
+Run `bundle exec i18n-tasks` to get the list of all the tasks with short descriptions.
 
 ### Check health
 

--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 TEXT
   s.post_install_message = <<~TEXT
     # Install default configuration:
-    cp $(i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/
+    cp $(bundle exec i18n-tasks gem-path)/templates/config/i18n-tasks.yml config/
     # Add an RSpec for missing and unused keys:
-    cp $(i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
+    cp $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
 TEXT
   s.homepage = 'https://github.com/glebm/i18n-tasks'
   s.metadata = { 'issue_tracker' => 'https://github.com/glebm/i18n-tasks' } if s.respond_to?(:metadata=)


### PR DESCRIPTION
- Recommend usage of 'bundle exec'.
- Update post installation instructions to use bundle exec.

My enviroment couldn't find the `i18n-task` executable without the use of `bundle exec`.
Showing this recommendation in the post installation message will make this more friendly for projects using this gem.