### PR TITLE
Suppress keyword arguments warnings in Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ sudo: false
 dist: xenial
 language: ruby
 rvm:
-- 2.5.3
-- 2.4.5
+- 2.7.0
+- 2.6.5
+- 2.5.7
+- 2.4.9
 - 2.3.8
 - jruby-9.2.6.0
 - rbx-3
@@ -21,12 +23,12 @@ before_script:
 script:
 - bundle exec rspec --format d
 - >
-  if [[ "$(rvm current)" = "ruby-2.5"* ]]; then
+  if [[ "$(rvm current)" = "ruby-2.7"* ]]; then
     bundle exec rubocop
   fi
 after_script:
 - >
-  if [[ "$(rvm current)" = "ruby-2.5"* ]]; then
+  if [[ "$(rvm current)" = "ruby-2.7"* ]]; then
     ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   fi
 env:

--- a/lib/i18n/tasks/command/commander.rb
+++ b/lib/i18n/tasks/command/commander.rb
@@ -22,7 +22,7 @@ module I18n::Tasks
         if opts.empty? || method(name).arity.zero?
           send name
         else
-          send name, opts
+          send name, **opts
         end
       end
 

--- a/lib/i18n/tasks/command/commands/health.rb
+++ b/lib/i18n/tasks/command/commands/health.rb
@@ -17,10 +17,10 @@ module I18n::Tasks
           fail CommandError, t('i18n_tasks.health.no_keys_detected') if stats[:key_count].zero?
           terminal_report.forest_stats forest, stats
           [
-            missing(opt),
-            unused(opt),
-            check_consistent_interpolations(opt),
-            check_normalized(opt)
+            missing(**opt),
+            unused(**opt),
+            check_consistent_interpolations(**opt),
+            check_normalized(**opt)
           ].detect { |result| result == :exit_1 }
         end
       end

--- a/lib/i18n/tasks/command/commands/interpolations.rb
+++ b/lib/i18n/tasks/command/commands/interpolations.rb
@@ -12,7 +12,7 @@ module I18n::Tasks
             args: %i[locales out_format]
 
         def check_consistent_interpolations(opt = {})
-          forest = i18n.inconsistent_interpolations(opt.slice(:locales, :base_locale))
+          forest = i18n.inconsistent_interpolations(**opt.slice(:locales, :base_locale))
           print_forest forest, opt, :inconsistent_interpolations
           :exit_1 unless forest.empty?
         end

--- a/lib/i18n/tasks/command/commands/missing.rb
+++ b/lib/i18n/tasks/command/commands/missing.rb
@@ -28,7 +28,7 @@ module I18n::Tasks
             args: %i[locales out_format missing_types]
 
         def missing(opt = {})
-          forest = i18n.missing_keys(opt.slice(:locales, :base_locale, :types))
+          forest = i18n.missing_keys(**opt.slice(:locales, :base_locale, :types))
           print_forest forest, opt, :missing_keys
           :exit_1 unless forest.empty?
         end

--- a/lib/i18n/tasks/command/commands/usages.rb
+++ b/lib/i18n/tasks/command/commands/usages.rb
@@ -32,7 +32,7 @@ module I18n::Tasks
             args: %i[locales out_format strict]
 
         def unused(opt = {})
-          forest = i18n.unused_keys(opt.slice(:locales, :strict))
+          forest = i18n.unused_keys(**opt.slice(:locales, :strict))
           print_forest forest, opt, :unused_keys
           :exit_1 unless forest.empty?
         end
@@ -43,7 +43,7 @@ module I18n::Tasks
             args: %i[locales out_format strict keep_order confirm pattern]
 
         def remove_unused(opt = {}) # rubocop:disable Metrics/AbcSize
-          unused_keys = i18n.unused_keys(opt.slice(:locales, :strict))
+          unused_keys = i18n.unused_keys(**opt.slice(:locales, :strict))
 
           if opt[:pattern]
             pattern_re = i18n.compile_key_pattern(opt[:pattern])

--- a/lib/i18n/tasks/data/tree/node.rb
+++ b/lib/i18n/tasks/data/tree/node.rb
@@ -28,7 +28,7 @@ module I18n::Tasks::Data::Tree
     end
 
     def derive(new_attr = {})
-      self.class.new(attributes.merge(new_attr))
+      self.class.new(**attributes.merge(new_attr))
     end
 
     def children=(children)

--- a/lib/i18n/tasks/data/tree/siblings.rb
+++ b/lib/i18n/tasks/data/tree/siblings.rb
@@ -273,7 +273,7 @@ module I18n::Tasks::Data::Tree
         build_forest(opts) do |forest|
           key_attrs.each do |(full_key, attr)|
             fail "Invalid key #{full_key.inspect}" if full_key.end_with?('.')
-            node = ::I18n::Tasks::Data::Tree::Node.new(attr.merge(key: split_key(full_key).last))
+            node = ::I18n::Tasks::Data::Tree::Node.new(**attr.merge(key: split_key(full_key).last))
             yield(full_key, node) if block
             forest[full_key] = node
           end

--- a/lib/i18n/tasks/data/tree/traversal.rb
+++ b/lib/i18n/tasks/data/tree/traversal.rb
@@ -60,14 +60,12 @@ module I18n::Tasks
         self
       end
 
-      def key_names(opts = {})
-        opts[:root] = false unless opts.key?(:root)
-        keys(opts).map { |key, _node| key }
+      def key_names(root: false)
+        keys(root: root).map { |key, _node| key }
       end
 
-      def key_values(opts = {})
-        opts[:root] = false unless opts.key?(:root)
-        keys(opts).map { |key, node| [key, node.value] }
+      def key_values(root: false)
+        keys(root: root).map { |key, node| [key, node.value] }
       end
 
       def root_key_values(sort = false)
@@ -141,18 +139,6 @@ module I18n::Tasks
           end
         end
         matches
-      end
-
-      # @return [Siblings]
-      def intersect_keys(other_tree, key_opts = {}, &block)
-        if block
-          select_keys(key_opts) do |key, node|
-            other_node = other_tree[key]
-            other_node && yield(key, node, other_node)
-          end
-        else
-          select_keys(key_opts) { |key, _node| other_tree[key] }
-        end
       end
 
       def grep_keys(match, opts = {})

--- a/lib/i18n/tasks/data/tree/traversal.rb
+++ b/lib/i18n/tasks/data/tree/traversal.rb
@@ -141,6 +141,18 @@ module I18n::Tasks
         matches
       end
 
+      # @return [Siblings]
+      def intersect_keys(other_tree, key_opts = {}, &block)
+        if block
+          select_keys(**key_opts.slice(:root)) do |key, node|
+            other_node = other_tree[key]
+            other_node && yield(key, node, other_node)
+          end
+        else
+          select_keys(**key_opts.slice(:root)) { |key, _node| other_tree[key] }
+        end
+      end
+
       def grep_keys(match, opts = {})
         select_keys(opts) do |full_key, _node|
           match === full_key # rubocop:disable Style/CaseEquality

--- a/lib/i18n/tasks/reports/terminal.rb
+++ b/lib/i18n/tasks/reports/terminal.rb
@@ -76,11 +76,11 @@ module I18n
 
         def forest_stats(forest, stats = task.forest_stats(forest))
           text  = if stats[:locale_count] == 1
-                    I18n.t('i18n_tasks.data_stats.text_single_locale', stats)
+                    I18n.t('i18n_tasks.data_stats.text_single_locale', **stats)
                   else
-                    I18n.t('i18n_tasks.data_stats.text', stats)
+                    I18n.t('i18n_tasks.data_stats.text', **stats)
                   end
-          title = Rainbow(I18n.t('i18n_tasks.data_stats.title', stats.slice(:locales))).bright
+          title = Rainbow(I18n.t('i18n_tasks.data_stats.title', **stats.slice(:locales))).bright
           print_info "#{Rainbow(title).cyan} #{Rainbow(text).cyan}"
         end
 

--- a/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
@@ -18,7 +18,7 @@ module I18n::Tasks::Scanners
     RECEIVER_MESSAGES = [nil, AST::Node.new(:const, [nil, :I18n])].product(%i[t t! translate translate!])
 
     def initialize(**args)
-      super(args)
+      super(**args)
       @parser = ::Parser::CurrentRuby.new
       @magic_comment_parser = ::Parser::CurrentRuby.new
       @call_finder = RubyAstCallFinder.new(

--- a/spec/file_system_data_spec.rb
+++ b/spec/file_system_data_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'File system i18n' do
       locale_data = { 'pizza' => keys, 'sushi' => keys }
       TestCodebase.setup
       TestCodebase.in_test_app_dir do
-        data[:en] = data[:en].merge!('en' => locale_data)
+        data[:en] = data[:en].merge!({'en' => locale_data})
         files = %w[pizza.en.yml sushi.en.yml]
         expect(Dir['*.yml'].sort).to eq(files.sort)
         files.each { |f| expect(YAML.load_file(f)['en']).to eq(File.basename(f, '.en.yml') => keys) }
@@ -120,7 +120,7 @@ RSpec.describe 'File system i18n' do
       locale_data = { 'pizza' => keys, 'sushi' => keys }
       TestCodebase.setup
       TestCodebase.in_test_app_dir do
-        data[:en] = data[:en].merge!('en' => locale_data)
+        data[:en] = data[:en].merge!({'en' => locale_data})
         files = %w[pizza.en.json sushi.en.json]
         expect(Dir['*.json'].sort).to eq(files.sort)
         files.each do |f|

--- a/spec/file_system_data_spec.rb
+++ b/spec/file_system_data_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe 'File system i18n' do
       locale_data = { 'pizza' => keys, 'sushi' => keys }
       TestCodebase.setup
       TestCodebase.in_test_app_dir do
-        data[:en] = data[:en].merge!({'en' => locale_data})
+        data[:en] = data[:en].merge!({ 'en' => locale_data }) # rubocop:disable Style/BracesAroundHashParameters
         files = %w[pizza.en.yml sushi.en.yml]
         expect(Dir['*.yml'].sort).to eq(files.sort)
         files.each { |f| expect(YAML.load_file(f)['en']).to eq(File.basename(f, '.en.yml') => keys) }
@@ -120,7 +120,7 @@ RSpec.describe 'File system i18n' do
       locale_data = { 'pizza' => keys, 'sushi' => keys }
       TestCodebase.setup
       TestCodebase.in_test_app_dir do
-        data[:en] = data[:en].merge!({'en' => locale_data})
+        data[:en] = data[:en].merge!({ 'en' => locale_data }) # rubocop:disable Style/BracesAroundHashParameters
         files = %w[pizza.en.json sushi.en.json]
         expect(Dir['*.json'].sort).to eq(files.sort)
         files.each do |f|

--- a/spec/locale_tree/siblings_spec.rb
+++ b/spec/locale_tree/siblings_spec.rb
@@ -97,6 +97,15 @@ RSpec.describe 'Tree siblings / forest' do
       expect { silence_stderr { a.set('a.b', new_node(key: 'b', value: 1)) } }.to_not raise_error
     end
 
+    it '#intersect' do
+      x = { a: 1, b: { ba: 1, bb: 2 } }
+      y = { b: { ba: 1, bc: 3 }, c: 1 }
+      intersection = { 'b' => { 'ba' => 1 } }
+      a = build_tree(x)
+      b = build_tree(y)
+      expect(a.intersect_keys(b, root: true).to_hash).to eq(intersection)
+    end
+
     it '#select_keys' do
       expect(build_tree(a: 1, b: 1).select_keys { |k, _node| k == 'b' }.to_hash).to eq('b' => 1)
     end

--- a/spec/locale_tree/siblings_spec.rb
+++ b/spec/locale_tree/siblings_spec.rb
@@ -97,15 +97,6 @@ RSpec.describe 'Tree siblings / forest' do
       expect { silence_stderr { a.set('a.b', new_node(key: 'b', value: 1)) } }.to_not raise_error
     end
 
-    it '#intersect' do
-      x = { a: 1, b: { ba: 1, bb: 2 } }
-      y = { b: { ba: 1, bc: 3 }, c: 1 }
-      intersection = { 'b' => { 'ba' => 1 } }
-      a = build_tree(x)
-      b = build_tree(y)
-      expect(a.intersect_keys(b, root: true).to_hash).to eq(intersection)
-    end
-
     it '#select_keys' do
       expect(build_tree(a: 1, b: 1).select_keys { |k, _node| k == 'b' }.to_hash).to eq('b' => 1)
     end

--- a/spec/support/keys_and_occurrences.rb
+++ b/spec/support/keys_and_occurrences.rb
@@ -10,7 +10,7 @@ module KeysAndOccurrences
   # rubocop:enable Metrics/ParameterLists
 
   def make_occurrences(occurrences)
-    occurrences.map { |attr| make_occurrence(attr) }
+    occurrences.map { |attr| make_occurrence(**attr) }
   end
 
   def make_key_occurrences(key, occurrences)

--- a/spec/support/trees.rb
+++ b/spec/support/trees.rb
@@ -16,7 +16,7 @@ module Trees
     I18n::Tasks::Data::Tree::Node.from_key_value(key, value)
   end
 
-  def new_node(attr = {})
-    I18n::Tasks::Data::Tree::Node.new(attr)
+  def new_node(**attr)
+    I18n::Tasks::Data::Tree::Node.new(**attr)
   end
 end


### PR DESCRIPTION
It suppresses keyword arguments warnings in Ruby 2.7. And it works well with Ruby 2.8 (the master branch).






# Problem


I18n-tasks displays warnings on Ruby 2.7.
I found the following warnings with `bundle exec rake`.

```
/path/to//glebm/i18n-tasks/spec/file_system_data_spec.rb:88: warning: Passing the keyword argument as the last hash parameter is deprecated
/path/to//glebm/i18n-tasks/spec/file_system_data_spec.rb:123: warning: Passing the keyword argument as the last hash parameter is deprecated
/path/to//glebm/i18n-tasks/lib/i18n/tasks/data/tree/siblings.rb:276: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to//glebm/i18n-tasks/spec/support/trees.rb:20: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to//glebm/i18n-tasks/lib/i18n/tasks/data/tree/traversal.rb:154: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/path/to//glebm/i18n-tasks/spec/support/keys_and_occurrences.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

And the test fails on Ruby 2.8.


# Solution


Add `**` to keyword arguments, etc.
see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/


And this pull request also enables Ruby 2.7 on Travis CI.