### PR TITLE
Fix: Ruby 2.7 warning

### DIFF
--- a/lib/i18n/tasks/data/adapter/yaml_adapter.rb
+++ b/lib/i18n/tasks/data/adapter/yaml_adapter.rb
@@ -9,7 +9,7 @@ module I18n::Tasks
           # @return [Hash] locale tree
           def parse(str, options)
             if YAML.method(:load).arity.abs == 2
-              YAML.load(str, options || {})
+              YAML.load(str, **(options || {}))
             else
               # older jruby and rbx 2.2.7 do not accept options
               YAML.load(str)


### PR DESCRIPTION
`gems/i18n-tasks-0.9.30/lib/i18n/tasks/data/adapter/yaml_adapter.rb:12: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`

I think this doesn't break anything else, so should be good to go. Thanks for the gem!