### PR TITLE
deepl plural and singular response handling

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -17,7 +17,12 @@ module I18n::Tasks::Translators
     protected
 
     def translate_values(list, from:, to:, **options)
-      DeepL.translate(list, to_deepl_compatible_locale(from), to_deepl_compatible_locale(to), options).map(&:text)
+      deepl = DeepL.translate(list, to_deepl_compatible_locale(from), to_deepl_compatible_locale(to), options)
+      if deepl.respond_to? 'map'
+        deepl.map(&:text)
+      else
+        [deepl.text]
+      end
     end
 
     def options_for_translate_values(**options)


### PR DESCRIPTION
It crashes when Deepl responds with a String. This fixes that. 