### PR TITLE
Fix: DEPRECATED use `bundle info vagrant` instead of `bundle show vagrant`

### DIFF
--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -32,7 +32,7 @@ data:
   # This data is not considered unused and is never written to.
   external:
     ## Example (replace %#= with %=):
-    # - "<%#= %x[bundle show vagrant].chomp %>/templates/locales/%{locale}.yml"
+    # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
 
   ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
   # router: conservative_router


### PR DESCRIPTION
Solves #350 

```ruby
$ %x[bundle info vagrant --path].chomp == %x[bundle show vagrant].chomp
 => true  
```