### PR TITLE
Get rid of deprecation warning on ruby 2.7.1

### DIFF
--- a/lib/i18n/tasks/command/dsl.rb
+++ b/lib/i18n/tasks/command/dsl.rb
@@ -42,8 +42,8 @@ module I18n::Tasks
         end
 
         # late-bound I18n.t for module bodies
-        def t(*args)
-          proc { I18n.t(*args) }
+        def t(*args, **opts)
+          proc { I18n.t(*args, **opts) }
         end
 
         # if class is a module, merge DSL definitions when it is included


### PR DESCRIPTION
Hi, I have no idea if I'm doing something useful here, or masking a problem that should be fixed elsewhere, or doing something even more stupid than that (Perl developer crosstraining to Ruby, sorry!) - but it does seem to make a deprecation warning go away for me so I thought I'd create a PR and let you decide.