### PR TITLE
Trying capitalized version of country code when accessing I18n configuration data

### DIFF
--- a/spec/missing_keys_spec.rb
+++ b/spec/missing_keys_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'MissingKeys' do
+  describe '#required_plural_keys_for_locale(locale)' do
+    let(:task) { ::I18n::Tasks::BaseTask.new }
+
+    def configuration_from(locale)
+      {
+        "#{locale}": {
+          i18n: {
+            plural: {
+              keys: %i[one other],
+              rule: -> {}
+            }
+          }
+        }
+      }
+    end
+
+    context 'when country code is lowercase' do
+      let(:locale) { 'en-gb' }
+      let(:configuration) { configuration_from(locale) }
+
+      before do
+        allow(task).to receive(:load_rails_i18n_pluralization!).with(locale).and_return(configuration)
+      end
+
+      it 'accesses the capitalized country code key and returns a populated set' do
+        expect(task.required_plural_keys_for_locale(locale)).not_to be_empty
+      end
+    end
+
+    context 'when country code is uppercase' do
+      let(:locale) { 'en-GB' }
+      let(:configuration) { configuration_from(locale) }
+
+      before do
+        allow(task).to receive(:load_rails_i18n_pluralization!).with(locale.downcase).and_return(configuration)
+      end
+
+      it 'accesses the capitalized country code key and returns a populated set' do
+        expect(task.required_plural_keys_for_locale(locale.downcase)).not_to be_empty
+      end
+    end
+
+    context 'when country code consists of three letters' do
+      let(:locale) { 'zh-YUE' }
+      let(:configuration) { configuration_from(locale) }
+
+      before do
+        allow(task).to receive(:load_rails_i18n_pluralization!).with(locale.downcase).and_return(configuration)
+      end
+
+      it 'accesses the country code key and returns a populated set' do
+        expect(task.required_plural_keys_for_locale(locale.downcase)).not_to be_empty
+      end
+    end
+
+    context 'when locale is not present in configuration hash' do
+      let(:locale) { 'zz-zz' }
+      let(:configuration) { configuration_from('en-us') }
+
+      before do
+        allow(task).to receive(:load_rails_i18n_pluralization!).with(locale).and_return(configuration)
+      end
+
+      it 'returns an empty set' do
+        expect(task.required_plural_keys_for_locale(locale)).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the follow-on to #336 that seems to have died last year. This issue is broken for those that need country codes (like me).

I've addressed the possibility of three digit country codes (like zh-YUE) and added a test that confirms it as well.

Otherwise, the PR code is largely @Foozie3Moons 

