### PR TITLE
Add webp extension to ALWAYS_EXCLUDE

### DIFF
--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -25,7 +25,8 @@ module I18n::Tasks
     }.freeze
 
     ALWAYS_EXCLUDE = %w[*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
-                        *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus].freeze
+                        *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus
+                        *.webp].freeze
 
     # Find all keys in the source and return a forest with the keys in absolute form and their occurrences.
     #


### PR DESCRIPTION
Always exclude `.webp` files

Added `*.webp` to `ALWAYS_EXCLUDE`

### Command

```
i18n-tasks missing
```

### Error Message

```
Error scanning app/assets/images/demo.webp: invalid byte sequence in UTF-8
```