### PR TITLE
Fix "undefined method map" error when translating single-pair with Deepl

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -17,7 +17,10 @@ module I18n::Tasks::Translators
     protected
 
     def translate_values(list, from:, to:, **options)
-      DeepL.translate(list, to_deepl_compatible_locale(from), to_deepl_compatible_locale(to), options).map(&:text)
+      output = DeepL.translate(list, to_deepl_compatible_locale(from), to_deepl_compatible_locale(to), options)
+      return output.map(&:text) unless output.is_a? DeepL::Resources::Text
+
+      [output.text]
     end
 
     def options_for_translate_values(**options)


### PR DESCRIPTION
When I tried to translate a single pair with the deepl translator, it raised an error:

```bash
$ bin/bundle exec i18n-tasks translate-missing --backend=deepl
bundler: failed to load command: i18n-tasks (/Users/lukas/.rbenv/versions/2.7.1/bin/i18n-tasks)
NoMethodError: undefined method `map' for #<DeepL::Resources::Text:0x00007fad7eb4f6d0>
Did you mean?  tap
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/deepl_translator.rb:20:in `translate_values'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:43:in `fetch_translations'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:33:in `block in translate_pairs'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:32:in `each'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:32:in `map'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:32:in `translate_pairs'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:16:in `block in translate_forest'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/data/tree/nodes.rb:16:in `each'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/data/tree/nodes.rb:16:in `each'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.31/lib/i18n/tasks/translators/base_translator.rb:15:in `inject'
  [...]
``` 

To reproduce, a single key/value pair is needed:
```yaml
en:
  home:
    name: Start
  other:
    [...]
```