### PR TITLE
Check external key is present in the current locale

### DIFF
--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -119,7 +119,7 @@ module I18n::Tasks
     end
 
     def locale_key_missing?(locale, key)
-      !key_value?(key, locale) && !external_key?(key) && !ignore_key?(key, :missing)
+      !key_value?(key, locale) && !external_key?(key, locale) && !ignore_key?(key, :missing)
     end
 
     # @param [::I18n::Tasks::Data::Tree::Siblings] forest

--- a/spec/fixtures/app/views/usages.html.slim
+++ b/spec/fixtures/app/views/usages.html.slim
@@ -2,3 +2,4 @@ p = t 'used.a'
 b = t 'used.a'
 
 p = t 'external.used'
+b = t 'external.missing_in_es'

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -93,6 +93,7 @@ RSpec.describe 'i18n-tasks' do
         es.missing_in_es_plural_1.a
         es.missing_in_es_plural_2.a
         en.only_in_es
+        es.external.missing_in_es
       ]
     end
     it 'detects missing' do
@@ -405,7 +406,7 @@ RSpec.describe 'i18n-tasks' do
       'config/locales/en.yml' => { 'en' => en_data }.to_yaml,
       'config/locales/es.yml' => { 'es' => es_data }.to_yaml,
       'config/locales/external/en.yml' =>
-          { 'en' => { 'external' => { 'used' => 'EN_TEXT', 'unused' => 'EN_TEXT' } } }.to_yaml,
+          { 'en' => { 'external' => { 'used' => 'EN_TEXT', 'unused' => 'EN_TEXT', 'missing_in_es' => 'EN_TEXT' } } }.to_yaml,
       'config/locales/external/es.yml' =>
           { 'es' => { 'external' => { 'used' => 'ES_TEXT', 'unused' => 'ES_TEXT' } } }.to_yaml,
       'config/locales/old_devise.en.yml' => { 'en' => { 'devise' => { 'a' => 'EN_TEXT' } } }.to_yaml,


### PR DESCRIPTION
If the key is only checked in the base locale, the missing keys check will not detect keys that are missing for other locales in an external gem.

Fixes #364 