### PR TITLE
Fix Deepl translator

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -17,9 +17,9 @@ module I18n::Tasks::Translators
     protected
 
     def translate_values(list, from:, to:, **options)
-      result = DeepL.translate(list, to_deepl_compatible_locale(from), to_deepl_compatible_locale(to), options).map(&:text)
+      result = DeepL.translate(list, to_deepl_compatible_locale(from), to_deepl_compatible_locale(to), options)
       if result.is_a?(DeepL::Resources::Text)
-        result.text
+        [result.text]
       else
         result.map(&:text)
       end


### PR DESCRIPTION
The issue raised in #363 still persists:

```
bundler: failed to load command: i18n-tasks (/Users/lukas/.rbenv/versions/2.7.1/bin/i18n-tasks)
NoMethodError: undefined method `map' for #<DeepL::Resources::Text:0x00007ff62e21ca60>
Did you mean?  tap
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.32/lib/i18n/tasks/translators/deepl_translator.rb:20:in `translate_values'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.32/lib/i18n/tasks/translators/base_translator.rb:43:in `fetch_translations'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.32/lib/i18n/tasks/translators/base_translator.rb:33:in `block in translate_pairs'
  /Users/lukas/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/i18n-tasks-0.9.32/lib/i18n/tasks/translators/base_translator.rb:32:in `each'
[...]
```

Also, the receiver expects an enumerable:
```
bundler: failed to load command: i18n-tasks (/Users/lukas/.rbenv/versions/2.7.1/bin/i18n-tasks)
NoMethodError: undefined method `each' for "Le mot de passe ne peut pas être modifié":String
  /Users/lukas/.rbenv/versions/2.7.1/bin/i18n-tasks:in `each'
[...]
```