### PR TITLE
fix: calling translation with same locale

### DIFF
--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -66,7 +66,7 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
 
   # @return [Array<String>] all available locales, base_locale is always first
   def locales
-    @config_sections[:locales] ||= data.locales
+    (@config_sections[:locales] ||= (data.locales - [base_locale])) - [base_locale]
   end
 
   # @return [String] default i18n locale


### PR DESCRIPTION
Fix error when calling google translator with same locale for from or to languages

Fixes https://github.com/glebm/i18n-tasks/issues/273