### PR TITLE
Add ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: focal
 language: ruby
 rvm:
 - ruby-head
+- 3.0.0
 - 2.7.0
 - 2.6.5
 - 2.5.7

--- a/lib/i18n/tasks/command/dsl.rb
+++ b/lib/i18n/tasks/command/dsl.rb
@@ -13,6 +13,7 @@ module I18n::Tasks
       def t(*args)
         I18n.t(*args)
       end
+      ruby2_keywords(:t) if respond_to?(:ruby2_keywords, true)
 
       module ClassMethods
         def cmd(name, conf = nil)


### PR DESCRIPTION
Fixes https://github.com/glebm/i18n-tasks/issues/370
Method I used should be compatible with all rubies, more info https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/ and in https://discuss.rubyonrails.org/t/new-2-7-3-0-keyword-argument-pain-point/74980/47
example: https://github.com/thbar/kiba/pull/93