### PR TITLE
Fix: jpeg invalid byte sequence when checking unused

### DIFF
--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -24,7 +24,7 @@ module I18n::Tasks
       strict: true
     }.freeze
 
-    ALWAYS_EXCLUDE = %w[*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
+    ALWAYS_EXCLUDE = %w[*.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
                         *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus
                         *.webp].freeze
 


### PR DESCRIPTION
I got this error backtrace when `i18n-tasks unused -l en`
```
/Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/pattern_scanner.rb:42:in `scan': invalid byte sequence in UTF-8 (ArgumentError)
  7: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/scanner_multiplexer.rb:34:in `block (3 levels) in collect_results'
  6: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/file_scanner.rb:26:in `keys'
  5: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/file_scanner.rb:57:in `traverse_files'
  4: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/files/file_finder.rb:30:in `traverse_files'
  3: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/files/file_finder.rb:30:in `map'
  2: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/file_scanner.rb:27:in `block in keys'
  1: from /Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/pattern_scanner.rb:42:in `scan_file'
/Users/dat/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/i18n-tasks-0.9.34/lib/i18n/tasks/scanners/pattern_scanner.rb:42:in `scan': Error scanning app/assets/images/intrust_super_logo.jpeg: invalid byte sequence in UTF-8 (I18n::Tasks::CommandError)
i18n-tasks: Error scanning app/assets/images/intrust_super_logo.jpeg: invalid byte sequence in UTF-8
```

Added *.jpeg to `ALWAYS_EXCLUDE`