### PR TITLE
Add deepl_host and deepl_version to translation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,9 @@ translation:
 ```yaml
 # config/i18n-tasks.yml
 translation:
-  deepl_api_key: <Deep Pro API key>
+  deepl_api_key: <DeepL Pro API key>
+  deepl_host: <optional>
+  deepl_version: <optional>
 ```
 
 <a name="yandex-translation-config"></a>

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -59,6 +59,8 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
       conf = (config[:translation] || {}).with_indifferent_access
       conf[:google_translate_api_key] = ENV['GOOGLE_TRANSLATE_API_KEY'] if ENV.key?('GOOGLE_TRANSLATE_API_KEY')
       conf[:deepl_api_key] = ENV['DEEPL_AUTH_KEY'] if ENV.key?('DEEPL_AUTH_KEY')
+      conf[:deepl_host] = ENV['DEEPL_HOST'] if ENV.key?('DEEPL_HOST')
+      conf[:deepl_version] = ENV['DEEPL_VERSION'] if ENV.key?('DEEPL_VERSION')
       conf[:yandex_api_key] = ENV['YANDEX_API_KEY'] if ENV.key?('YANDEX_API_KEY')
       conf
     end

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -67,9 +67,15 @@ module I18n::Tasks::Translators
 
     def configure_api_key!
       api_key = @i18n_tasks.translation_config[:deepl_api_key]
+      host = @i18n_tasks.translation_config[:deepl_host]
+      version = @i18n_tasks.translation_config[:deepl_version]
       fail ::I18n::Tasks::CommandError, I18n.t('i18n_tasks.deepl_translate.errors.no_api_key') if api_key.blank?
 
-      DeepL.configure { |config| config.auth_key = api_key }
+      DeepL.configure { |config|
+        config.auth_key = api_key
+        config.host = host unless host.blank?
+        config.version = version unless version.blank?
+      }
     end
   end
 end

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -90,6 +90,8 @@ search:
 #   # DeepL Pro Translate
 #   # Get an API key and subscription at https://www.deepl.com/pro to use DeepL Pro
 #   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
+#   # deepl_host: "https://api.deepl.com"
+#   # deepl_version: "v2"
 
 ## Do not consider these keys missing:
 # ignore_missing:


### PR DESCRIPTION
In order to use Deepl API Free, it is necessary to set an alternative API host. This PR adds support for Deepl host and version as optional configuration parameters.

Reference: https://github.com/wikiti/deepl-rb#usage
 