### PR TITLE
Fix not ignoring missing for pluralization

### DIFF
--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -65,7 +65,7 @@ module I18n::Tasks
         plural_nodes data[locale] do |node|
           children = node.children
           present_keys = Set.new(children.map { |c| c.key.to_sym })
-          next if ignore_key?(node.key_names.first, :missing)
+          next if ignore_key?(node.full_key(root: false), :missing)
           next if present_keys.superset?(required_keys)
 
           tree[node.full_key] = node.derive(

--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -65,6 +65,7 @@ module I18n::Tasks
         plural_nodes data[locale] do |node|
           children = node.children
           present_keys = Set.new(children.map { |c| c.key.to_sym })
+          next if ignore_key?(node.key_names.first, :missing)
           next if present_keys.superset?(required_keys)
 
           tree[node.full_key] = node.derive(

--- a/spec/plural_keys_spec.rb
+++ b/spec/plural_keys_spec.rb
@@ -25,13 +25,23 @@ RSpec.describe 'Plural keys' do
           one: 'one',
           other: '%{count}'
         }
+      },
+
+      ignored_pattern: {
+        plural_key: {
+          other: '%{count}'
+        }
       }
     }
   end
 
   around do |ex|
     TestCodebase.setup(
-      'config/i18n-tasks.yml' => { base_locale: 'en', locales: %w[en ar] }.to_yaml,
+      'config/i18n-tasks.yml' => {
+        base_locale: 'en',
+        locales: %w[en ar],
+        ignore_missing: ['ignored_pattern.*']
+      }.to_yaml,
       'config/locales/en.yml' => { en: base_keys }.to_yaml,
       'config/locales/ar.yml' => { ar: base_keys }.to_yaml
     )


### PR DESCRIPTION
References #331

When you add a pattern for ignoring missing, it is currently not ignoring the pluralization for that pattern.
This commit fixes that, by skipping plural nodes that were ignored in the configuration for `ignore_missing`.