### PR TITLE
Use sha for interpolation replacement

### DIFF
--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -94,7 +94,6 @@ module I18n::Tasks
       end
 
       INTERPOLATION_KEY_RE = /%\{[^}]+}/.freeze
-      UNTRANSLATABLE_STRING = 'zxzxzx'
 
       # @param [String] value
       # @return [String] 'hello, %{name}' => 'hello, <round-trippable string>'


### PR DESCRIPTION
Fixes #390

Uses a digest of the interpolation variable to replace/restore during translation rather than `zxzxzx` plus a counter for the current interpolated variable. We will be sending more characters to google translate with this fix but this seemed an acceptable trade-off.