### PR TITLE
Replace translation replacement token 'zxzxzx' with 'X__'

### DIFF
--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -94,7 +94,7 @@ module I18n::Tasks
       end
 
       INTERPOLATION_KEY_RE = /%\{[^}]+}/.freeze
-      UNTRANSLATABLE_STRING = 'zxzxzx'
+      UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value
       # @return [String] 'hello, %{name}' => 'hello, <round-trippable string>'


### PR DESCRIPTION
Closes #390

After attempt in #391, it was suggested to try a different token which will remain unchanged after going through a translation service.