### PR TITLE
add --config to specify config file location

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
         desc:
           all_locales: Do not expect key patterns to start with a locale, instead apply them to all
             locales implicitly.
+          config: Override config location
           confirm: Confirm automatically
           data_format: 'Data format: %{valid_text}.'
           keep_order: Keep the order of the keys

--- a/lib/i18n/tasks/base_task.rb
+++ b/lib/i18n/tasks/base_task.rb
@@ -39,7 +39,8 @@ module I18n
       include Data
       include Stats
 
-      def initialize(config = {})
+      def initialize(config = {}, config_file: nil)
+        @config_override = config_file
         self.config = config || {}
       end
 

--- a/lib/i18n/tasks/cli.rb
+++ b/lib/i18n/tasks/cli.rb
@@ -34,7 +34,18 @@ class I18n::Tasks::CLI
   end
 
   def run(argv)
-    I18n.with_locale(base_task.internal_locale) do
+    argv.each_with_index do |arg, i|
+      if ["--config", "-c"].include?(arg)
+        if File.exist?(argv[i+1])
+          @config_file = argv[i+1]
+          break
+        else
+          error "Config file doesn't exist: #{argv[i+1]}", 128
+        end
+      end
+    end
+
+    I18n.with_locale(base_task(config_file: @config_file).internal_locale) do
       name, *options = parse!(argv.dup)
       context.run(name, *options)
     end
@@ -52,8 +63,8 @@ class I18n::Tasks::CLI
 
   private
 
-  def base_task
-    @base_task ||= I18n::Tasks::BaseTask.new
+  def base_task(config_file: nil)
+    @base_task ||= I18n::Tasks::BaseTask.new(config_file: config_file)
   end
 
   def parse!(argv)

--- a/lib/i18n/tasks/command/commands/health.rb
+++ b/lib/i18n/tasks/command/commands/health.rb
@@ -9,7 +9,7 @@ module I18n::Tasks
         cmd :health,
             pos: '[locale ...]',
             desc: t('i18n_tasks.cmd.desc.health'),
-            args: %i[locales out_format]
+            args: %i[locales out_format config]
 
         def health(opt = {})
           forest = i18n.data_forest(opt[:locales])

--- a/lib/i18n/tasks/command/options/common.rb
+++ b/lib/i18n/tasks/command/options/common.rb
@@ -28,6 +28,12 @@ module I18n::Tasks
             '--value VALUE',
             t('i18n_tasks.cmd.args.desc.value')
 
+        arg :config,
+            '-c',
+            '--config FILE',
+            t('i18n_tasks.cmd.args.desc.config')
+
+
         def arg_or_pos!(key, opts)
           opts[key] ||= opts[:arguments].try(:shift)
         end

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
   ].freeze
 
   def file_config
-    file   = CONFIG_FILES.detect { |f| File.exist?(f) }
+    file   = @config_override || CONFIG_FILES.detect { |f| File.exist?(f) }
     # rubocop:disable Security/Eval
     config = file && YAML.load(eval(Erubi::Engine.new(File.read(file, encoding: 'UTF-8')).src))
     # rubocop:enable Security/Eval


### PR DESCRIPTION
We are running I18n checks for our backend translations and also for for frontend JS files. We do have a seperated config file for those and had a rspec test like this


```
 context 'JS' do
    before do
      @config_files_was = I18n::Tasks::Configuration::CONFIG_FILES
      I18n::Tasks::Configuration::CONFIG_FILES = %w[
        config/i18n-js-tasks.yml
      ].freeze
    end

    after do
      I18n::Tasks::Configuration::CONFIG_FILES = @config_files_was
    end

    it 'files are normalized' do
      non_normalized = i18n.non_normalized_paths
      error_message = "The following files need to be normalized:\n" \
                      "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \
                      'Please run `rake i18n_js_tasks:run["normalize"]` to fix'
      expect(non_normalized).to be_empty, error_message
    end
  end
```


Since our test suite is big and takes a while (~1 hour) on CI , we don't want to waste resources anymore, only to realize after the test run, that a translation key is missing. Quite inefficient and unnecessary. We looked for a way to also run the config file for our JS checks via shell command, but that wasn't possible.

We found a way of actually adding the config file to the health check. Since this gem actually relies heavily on the config file before it does anything else, i had to inject the config file loadup right at the beginning.

Most likely this PR won't be accepted and if there are just minor things that are missing i'm happy to take on them, but i fear that it's a bigger architecture problem. Maybe there are better ways to actually implement this which i didn't find on my first try.

If this won't get merged, maybe somebody else might stumble across this and it's helpful for him, or at least this PR is acting as an inspiration for future progress.


We can call this now with `i18n-tasks health` (default config location) and `ì18n-tasks health --config config/i18n-js-yml` (for our JS tasks)
