### PR TITLE
Allow forward slash in locale key

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž])/.freeze
+    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž\/])/.freeze
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/.freeze
 
     def valid_key?(key)

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'i18n/tasks/scanners/ruby_key_literals'
+
+RSpec.describe 'RubyKeyLiterals' do
+  let(:scanner) do
+    Object.new.extend I18n::Tasks::Scanners::RubyKeyLiterals
+  end
+
+  describe '#valid_key?' do
+    it 'allows forward slash in key' do
+      expect(scanner).to be_valid_key('category/product')
+    end
+  end
+end


### PR DESCRIPTION
This adds `/` as a valid character in translation keys.

Closes #380