### PR TITLE
Allow hash literals in dynamic keys

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž\/])/.freeze
+    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž\/'"\[\]])/.freeze
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/.freeze
 
     def valid_key?(key)

--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -2,10 +2,10 @@
 
 module I18n::Tasks::Scanners
   module RubyKeyLiterals
-    LITERAL_RE = /:?".+?"|:?'.+?'|:\w+/.freeze
+    LITERAL_RE = /:?"[\[]*(?:\[\s*")?.+(?:"\s*\])?"|:?'.+?'|:\w+/.freeze
 
     # Match literals:
-    # * String: '', "#{}"
+    # * String: '', "#{}", "#{hash["key"]}"
     # * Symbol: :sym, :'', :"#{}"
     def literal_re
       LITERAL_RE

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -21,8 +21,27 @@ RSpec.describe 'RubyKeyLiterals' do
       end
 
       context 'double quoted' do
-        let(:key) { %q("#{some_key}") } # rubocop:disable Lint/InterpolationCheck
-        it { is_expected.to eq(key) }
+        context 'var' do
+          let(:key) { %q("#{some_key}") } # rubocop:disable Lint/InterpolationCheck
+          it { is_expected.to eq(key) }
+        end
+
+        context 'hash' do
+          context 'double quoted key' do
+            let(:key) { %q("#{some_hash["some_key"]}") } # rubocop:disable Lint/InterpolationCheck
+            it { is_expected.to eq(key) }
+          end
+
+          context 'single quoted key' do
+            let(:key) { %q("#{some_hash['some_key']}") } # rubocop:disable Lint/InterpolationCheck
+            it { is_expected.to eq(key) }
+          end
+
+          context 'symbol key' do
+            let(:key) { %q("#{some_hash[:some_key]}") } # rubocop:disable Lint/InterpolationCheck
+            it { is_expected.to eq(key) }
+          end
+        end
       end
     end
 

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -8,6 +8,42 @@ RSpec.describe 'RubyKeyLiterals' do
     Object.new.extend I18n::Tasks::Scanners::RubyKeyLiterals
   end
 
+  describe '#literal_re' do
+    subject do
+      /(#{scanner.literal_re})/x =~ key
+      Regexp.last_match(1)
+    end
+
+    context 'string' do
+      context 'single quoted' do
+        let(:key) { %('some_key') }
+        it { is_expected.to eq(key) }
+      end
+
+      context 'double quoted' do
+        let(:key) { %q("#{some_key}") } # rubocop:disable Lint/InterpolationCheck
+        it { is_expected.to eq(key) }
+      end
+    end
+
+    context 'symbol' do
+      context 'regular literal' do
+        let(:key) { %(:some_key) }
+        it { is_expected.to eq(key) }
+      end
+
+      context 'single quoted' do
+        let(:key) { %(:'some_key') }
+        it { is_expected.to eq(key) }
+      end
+
+      context 'double quoted' do
+        let(:key) { %q(:"#{some_key}") } # rubocop:disable Lint/InterpolationCheck
+        it { is_expected.to eq(key) }
+      end
+    end
+  end
+
   describe '#valid_key?' do
     it 'allows forward slash in key' do
       expect(scanner).to be_valid_key('category/product')

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -64,8 +64,17 @@ RSpec.describe 'RubyKeyLiterals' do
   end
 
   describe '#valid_key?' do
-    it 'allows forward slash in key' do
-      expect(scanner).to be_valid_key('category/product')
+    subject { scanner }
+
+    context 'slash in key' do
+      let(:key) { 'category/product' }
+      it { is_expected.to be_valid_key(key) }
+    end
+
+    context 'hash in key' do
+      let(:key) { 'category/product' }
+      let(:key) { 'some_hash["some_key"]' }
+      it { is_expected.to be_valid_key(key) }
     end
   end
 end


### PR DESCRIPTION
Fix https://github.com/glebm/i18n-tasks/issues/354

Hash literals in dynamic keys such as `t("loopup.something.in.#{somearray["element"]}")` are not interpreted correctly.
This patch allows hash literals in dynamic keys.