### PR TITLE
Ignore source map files by default

### DIFF
--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -27,7 +27,7 @@ module I18n::Tasks
 
     ALWAYS_EXCLUDE = %w[*.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
                         *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus
-                        *.webp].freeze
+                        *.webp *.map].freeze
 
     # Find all keys in the source and return a forest with the keys in absolute form and their occurrences.
     #

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -72,7 +72,7 @@ search:
   #  -
 
   ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
-  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
+  ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json *.map)
   exclude:
     - app/assets/images
     - app/assets/fonts


### PR DESCRIPTION
[Source maps](https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map) are becoming more popular. Rails 7 is moving towards replacing Webpacker with other tools, for example [jsbundling-rails](https://github.com/rails/jsbundling-rails). This gem puts build files in the `app/assets/builds` directory:

> This gem provides installers to get you going with the bundler of your choice in a new Rails application, and a convention to use app/assets/builds to hold your bundled output as artifacts that are not checked into source control

If you use `jsbundling-rails` and enable source maps they are picked up by i18n-tasks, for example:

>❯ i18n-tasks missing
Missing translations (2) | i18n-tasks v0.9.35
+--------+-----+-------------------------------------------------+
| Locale | Key | Value in other locales or source                |
+--------+-----+-------------------------------------------------+
|  all   | !0  | app/assets/builds/application.js.map:4 (1 more) |
|  all   | !1  | app/assets/builds/application.js.map:4 (2 more) |
+--------+-----+-------------------------------------------------+

I think it makes sense to ignore these by default, so I've simply added the extension to the exclude list. 

Let me know if this is not a way forward, I'm happy to change the approach. 

I also just noticed that the list of extensions in the template .yml does not match the actual exclude list, is that something to sync up as well?