### PR TITLE
Change order of arguments for base task

### DIFF
--- a/lib/i18n/tasks/base_task.rb
+++ b/lib/i18n/tasks/base_task.rb
@@ -39,7 +39,7 @@ module I18n
       include Data
       include Stats
 
-      def initialize(config = {}, config_file: nil)
+      def initialize(config_file: nil, **config)
         @config_override = config_file
         self.config = config || {}
       end


### PR DESCRIPTION
Fixes #401 
As suggested, we propose to change the order of arguments and use the splat operator to allow the introduction of the new `config_file` argument while maintaining compatiblity