### PR TITLE
Revert literal change

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž\/'"\[\]])/.freeze
+    VALID_KEY_CHARS = /(?:[[:word:]]|[-.?!:;À-ž\/])/.freeze
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/.freeze
 
     def valid_key?(key)

--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -2,10 +2,10 @@
 
 module I18n::Tasks::Scanners
   module RubyKeyLiterals
-    LITERAL_RE = /:?"[\[]*(?:\[\s*")?.+(?:"\s*\])?"|:?'.+?'|:\w+/.freeze
+    LITERAL_RE = /:?".+?"|:?'.+?'|:\w+/.freeze
 
     # Match literals:
-    # * String: '', "#{}", "#{hash["key"]}"
+    # * String: '', "#{}"
     # * Symbol: :sym, :'', :"#{}"
     def literal_re
       LITERAL_RE

--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -2,9 +2,7 @@
 
 module I18n::Tasks::Scanners
   module RubyKeyLiterals
-    # NOTE
-    # "#{double_quoted["hash_pattern"]}" | "#{double_quoted_pattern}" | 'single_quoted_pattern' | :symbol_pattern
-    LITERAL_RE = /:?"[^\[]+\["[^"]+"\].+"|:?".+?"|:?'.+?'|:\w+/.freeze
+    LITERAL_RE = /:?"[\[]*(?:\[\s*")?.+(?:"\s*\])?"|:?'.+?'|:\w+/.freeze
 
     # Match literals:
     # * String: '', "#{}", "#{hash["key"]}"

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -21,27 +21,8 @@ RSpec.describe 'RubyKeyLiterals' do
       end
 
       context 'double quoted' do
-        context 'var' do
-          let(:key) { %q("#{some_key}") } # rubocop:disable Lint/InterpolationCheck
-          it { is_expected.to eq(key) }
-        end
-
-        context 'hash' do
-          context 'double quoted key' do
-            let(:key) { %q("#{some_hash["some_key"]}") } # rubocop:disable Lint/InterpolationCheck
-            it { is_expected.to eq(key) }
-          end
-
-          context 'single quoted key' do
-            let(:key) { %q("#{some_hash['some_key']}") } # rubocop:disable Lint/InterpolationCheck
-            it { is_expected.to eq(key) }
-          end
-
-          context 'symbol key' do
-            let(:key) { %q("#{some_hash[:some_key]}") } # rubocop:disable Lint/InterpolationCheck
-            it { is_expected.to eq(key) }
-          end
-        end
+        let(:key) { %q("#{some_key}") } # rubocop:disable Lint/InterpolationCheck
+        it { is_expected.to eq(key) }
       end
     end
 

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -8,42 +8,6 @@ RSpec.describe 'RubyKeyLiterals' do
     Object.new.extend I18n::Tasks::Scanners::RubyKeyLiterals
   end
 
-  describe '#literal_re' do
-    subject do
-      /(#{scanner.literal_re})/x =~ key
-      Regexp.last_match(1)
-    end
-
-    context 'string' do
-      context 'single quoted' do
-        let(:key) { %('some_key') }
-        it { is_expected.to eq(key) }
-      end
-
-      context 'double quoted' do
-        let(:key) { %q("#{some_key}") } # rubocop:disable Lint/InterpolationCheck
-        it { is_expected.to eq(key) }
-      end
-    end
-
-    context 'symbol' do
-      context 'regular literal' do
-        let(:key) { %(:some_key) }
-        it { is_expected.to eq(key) }
-      end
-
-      context 'single quoted' do
-        let(:key) { %(:'some_key') }
-        it { is_expected.to eq(key) }
-      end
-
-      context 'double quoted' do
-        let(:key) { %q(:"#{some_key}") } # rubocop:disable Lint/InterpolationCheck
-        it { is_expected.to eq(key) }
-      end
-    end
-  end
-
   describe '#valid_key?' do
     it 'allows forward slash in key' do
       expect(scanner).to be_valid_key('category/product')

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -64,17 +64,8 @@ RSpec.describe 'RubyKeyLiterals' do
   end
 
   describe '#valid_key?' do
-    subject { scanner }
-
-    context 'slash in key' do
-      let(:key) { 'category/product' }
-      it { is_expected.to be_valid_key(key) }
-    end
-
-    context 'hash in key' do
-      let(:key) { 'category/product' }
-      let(:key) { 'some_hash["some_key"]' }
-      it { is_expected.to be_valid_key(key) }
+    it 'allows forward slash in key' do
+      expect(scanner).to be_valid_key('category/product')
     end
   end
 end


### PR DESCRIPTION
Revert https://github.com/glebm/i18n-tasks/pull/405 https://github.com/glebm/i18n-tasks/pull/397

ref https://github.com/glebm/i18n-tasks/issues/408

My changes of Ruby literals only considered ERB...
`RubyKeyLiterals` class should not have ERB literals.