### PR TITLE
Improve tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,30 +9,27 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['3.0.1', '2.7.3', '2.6.7']
+    env:
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+      GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}
+      CI: 1
+      COVERAGE: 1
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@477b21f02be01bcb8030d50f37cfec92bfa615b6
         with:
           ruby-version: ${{ matrix.ruby-version }}
-      - name: "Determine whether to run coverage"
-        if: ${{ startsWith(matrix.ruby-version, '3.0') && github.ref == 'refs/heads/main' }}
-        run: echo COVERAGE=1 >> $GITHUB_ENV
+      - name: "Determine whether to upload coverage"
+        if: ${{ env.CC_TEST_REPORTER_ID && startsWith(matrix.ruby-version, '3.0') && github.ref == 'refs/heads/main' }}
+        run: echo UPLOAD_COVERAGE=1 >> $GITHUB_ENV
       - name: Install dependencies
         run: bundle install
       - name: Run tests
-        if: ${{ !env.COVERAGE }}
+        if: ${{ !env.UPLOAD_COVERAGE }}
         run: bundle exec rake
-        env:
-          GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}
-      - name: Test & publish code coverage
+      - name: Run tests and upload coverage
         uses: paambaati/codeclimate-action@v3.0.0
-        if: ${{ env.COVERAGE }}
+        if: ${{ env.UPLOAD_COVERAGE }}
         with:
           coverageCommand: bundle exec rake
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-          GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}
-    env:
-      TRAVIS: 1
-      CI: 1

--- a/.simplecov
+++ b/.simplecov
@@ -3,6 +3,6 @@
 unless defined?(RUBY_ENGINE) && %w[rbx jruby].include?(RUBY_ENGINE)
   SimpleCov.start do
     add_filter '/spec/'
-    formatter SimpleCov::Formatter::HTMLFormatter unless ENV['TRAVIS']
+    formatter SimpleCov::Formatter::HTMLFormatter unless ENV['CI']
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ platform :rbx do
   gem 'racc'
 end
 
-unless ENV['TRAVIS']
+unless ENV['CI']
   group :development do
     gem 'byebug', platforms: %i[mri mswin x64_mingw_21 x64_mingw_22], require: false # rubocop:disable Naming/VariableNumber
     gem 'rubinius-debugger', platform: :rbx, require: false

--- a/spec/google_translate_spec.rb
+++ b/spec/google_translate_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe 'Google Translation' do
       it 'works' do
         skip 'temporarily disabled on JRuby due to https://github.com/jruby/jruby/issues/4802' if RUBY_ENGINE == 'jruby'
         skip 'GOOGLE_TRANSLATE_API_KEY env var not set' unless ENV['GOOGLE_TRANSLATE_API_KEY']
+        skip 'GOOGLE_TRANSLATE_API_KEY env var is empty' if ENV['GOOGLE_TRANSLATE_API_KEY'].empty?
         in_test_app_dir do
           task.data[:en] = build_tree('en' => {
                                         'common' => {

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -19,11 +19,6 @@ RSpec.describe I18n do
   end
 
   it 'files are normalized' do
-    # Skip this test if on TRAVIS + MRI.
-    if ENV['TRAVIS'] && RUBY_ENGINE == 'ruby'
-      skip 'Travis CI has an older version of libyaml where the formatting differs.'
-    end
-
     non_normalized = i18n.non_normalized_paths
     error_message = "The following files need to be normalized:\n" \
                     "#{non_normalized.map { |path| "  #{path}" }.join("\n")}\n" \


### PR DESCRIPTION
1. Only run Google Translate test if an API key is available.
2. Only run and publish coverage if an API key is available.
3. Clean up workflow structure and some related code.