### PR TITLE
Ensured Aliased values work

### DIFF
--- a/lib/i18n/tasks/data/adapter/yaml_adapter.rb
+++ b/lib/i18n/tasks/data/adapter/yaml_adapter.rb
@@ -9,7 +9,7 @@ module I18n::Tasks
           # @return [Hash] locale tree
           def parse(str, options)
             if YAML.method(:load).arity.abs == 2
-              YAML.load(str, **(options || {}))
+              YAML.safe_load(str, **(options || {}), permitted_classes: [Symbol], aliases: true)
             else
               # older jruby and rbx 2.2.7 do not accept options
               YAML.load(str)

--- a/spec/file_system_data_spec.rb
+++ b/spec/file_system_data_spec.rb
@@ -67,15 +67,16 @@ RSpec.describe 'File system i18n' do
     after { TestCodebase.teardown }
 
     it '#get' do
-      data.config = { read: ['a.yml', '{b,c}.yml'] }
+      data.config = { read: ['a.yml', '{b,c}.yml', 'd.yml'] }
       TestCodebase.setup(
         'a.yml' => { en: { a: 1 } }.stringify_keys.to_yaml,
         'b.yml' => { en: { b: 1 } }.stringify_keys.to_yaml,
-        'c.yml' => { en: { c: 1 } }.stringify_keys.to_yaml
+        'c.yml' => { en: { c: 1 } }.stringify_keys.to_yaml,
+        'd.yml' => "---\n:en:\n :d: &d test\n :d_alias: *d\n"
       )
       TestCodebase.in_test_app_dir do
         actual = data[:en].to_hash['en'].symbolize_keys
-        expect(actual).to eq(a: 1, b: 1, c: 1)
+        expect(actual).to eq(a: 1, b: 1, c: 1, d: 'test', d_alias: 'test')
       end
     end
 

--- a/spec/file_system_data_spec.rb
+++ b/spec/file_system_data_spec.rb
@@ -72,7 +72,12 @@ RSpec.describe 'File system i18n' do
         'a.yml' => { en: { a: 1 } }.stringify_keys.to_yaml,
         'b.yml' => { en: { b: 1 } }.stringify_keys.to_yaml,
         'c.yml' => { en: { c: 1 } }.stringify_keys.to_yaml,
-        'd.yml' => "---\n:en:\n :d: &d test\n :d_alias: *d\n"
+        'd.yml' => <<~YAML
+          ---
+          en:
+            d: &d test
+            d_alias: *d
+        YAML
       )
       TestCodebase.in_test_app_dir do
         actual = data[:en].to_hash['en'].symbolize_keys


### PR DESCRIPTION
This updates the YamlAdapter to use safe_load with standard defaults, this ensures compatibility with Psych 4.0 that was made standard in Ruby 3.1, while still being compatible with older versions of ruby

[closes #412]