### PR TITLE
Repair emojis after dump of yaml

### DIFF
--- a/lib/i18n/tasks/data/adapter/yaml_adapter.rb
+++ b/lib/i18n/tasks/data/adapter/yaml_adapter.rb
@@ -5,6 +5,8 @@ module I18n::Tasks
   module Data
     module Adapter
       module YamlAdapter
+        EMOJI_REGEX = /\\u[\da-f]{8}/i
+
         class << self
           # @return [Hash] locale tree
           def parse(str, options)
@@ -18,7 +20,12 @@ module I18n::Tasks
 
           # @return [String]
           def dump(tree, options)
-            tree.to_yaml(options || {})
+            restore_emojis(tree.to_yaml(options || {}))
+          end
+
+          # @return [String]
+          def restore_emojis(yaml)
+            yaml.gsub(EMOJI_REGEX) { |m| [m[-8..].to_i(16)].pack("U") }
           end
         end
       end

--- a/spec/emoji_retention_spec.rb
+++ b/spec/emoji_retention_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Emoji Retention in dump' do
+  let!(:task) { I18n::Tasks::BaseTask.new }
+
+  let(:yaml) { { 'a' => 'hello %{world}😀', 'b' => 'foo', 'c' => { 'd' => 'hello %{name}' }, 'e' => 'ok' } }
+
+  describe '.dump' do
+    it 'does not strip emojis from yaml' do
+      dumped_yaml = I18n::Tasks::Data::Adapter::YamlAdapter.dump(
+        yaml,
+        {}
+      )
+      expect(dumped_yaml).to include('😀')
+    end
+  end
+end

--- a/spec/fixtures/app/views/index.html.slim
+++ b/spec/fixtures/app/views/index.html.slim
@@ -35,6 +35,8 @@ p = Spree.t 'not_a_key'
 = t 'reference-ok-nested.a'
 = t 'reference-missing-target.a'
 
+= t 'emoji.smile'
+
 p = t 'missing_key_ending_in_colon.key:'
 p = t(:ignored_in_strict_mode, scope: [:search, params[:action]]), query: params[:q]
 = t "a.b", scope: "scope.subscope"

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe 'i18n-tasks' do
         es.external.missing_in_es
       ]
     end
+
     it 'detects missing' do
       es_keys = expected_missing_keys_diff.grep(/^es\./) +
                 (expected_missing_keys_in_source.map { |k| k[0] == '⮕' ? k : "es.#{k}" })
@@ -238,6 +239,17 @@ RSpec.describe 'i18n-tasks' do
         expect(File).not_to exist 'config/locales/old_devise.en.yml'
       end
     end
+
+    it 'does not remove emojis' do
+      in_test_app_dir do
+        run_cmd 'normalize'
+        en_yml_data = i18n_task.data.reload['en'].select_keys do |_k, node|
+          node.data[:path] == 'config/locales/en.yml'
+        end
+
+        expect(en_yml_data[:en][:emoji][:smile].value).to eq('😀')
+      end
+    end
   end
 
   describe 'add_missing' do
@@ -371,6 +383,7 @@ RSpec.describe 'i18n-tasks' do
             'summary' => v
           }
         },
+        'emoji' => { 'smile' => '😀' },
         'numeric' => { 'a' => v_num },
         'plural' => { 'a' => { 'one' => v, 'other' => "%{count} #{v}s" } },
         'scoped' => { 'x' => v },
@@ -404,6 +417,7 @@ RSpec.describe 'i18n-tasks' do
     es_data['ignore_eq_base_all']['a']  = 'EN_TEXT'
     es_data['ignore_eq_base_es']['a']   = 'EN_TEXT'
     es_data['only_in_es']               = 1
+    es_data['emoji']['smile']           = '😄'
     es_data['present_in_es_but_not_en'] = { 'a' => 'ES_TEXT' }
 
     fs = fixtures_contents.merge(


### PR DESCRIPTION
This pull request restores the encoded emojis right after the dump.
This allows developers to use emojis in their YAML translations which was a big issue for as at @renuo. As we would have to manually repair the emojis after normalization.

The code to restore the emojis was taken/extracted from https://github.com/ruby/psych/issues/371#issuecomment-947509865. 

This pr can be seen as a quickfix solution for the issue. We are working on a mergeable pr for psych. A solution in this repo seems more likely to be merged.

Relevant issues: https://github.com/ruby/psych/issues/371