### PR TITLE
Ignore key if scope cannot be evaluated

### DIFF
--- a/lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb
@@ -27,6 +27,8 @@ module I18n::Tasks::Scanners::AstMatchers
 
       key, default_arg = process_options(node: second_arg_node, key: key)
 
+      return if key.nil?
+
       [
         full_key(receiver: receiver, key: key, location: location, calling_method: method_name),
         I18n::Tasks::Scanners::Results::Occurrence.from_range(
@@ -71,7 +73,7 @@ module I18n::Tasks::Scanners::AstMatchers
           array_flatten: true,
           array_reject_blank: true
         )
-        return [key, nil] if scope.nil? && scope_node.type != :nil
+        return nil if scope.nil? && scope_node.type != :nil
 
         key = [scope, key].join('.') unless scope == ''
       end

--- a/spec/fixtures/used_keys/a.rb
+++ b/spec/fixtures/used_keys/a.rb
@@ -13,4 +13,10 @@ class A
     I18n.t('activerecord.attributes.absolute.attribute')
     translate('activerecord.attributes.absolute.attribute')
   end
+
+  SCOPE_CONSTANT = 'path.in.translation.file'.freeze
+  def issue441
+    t('ignore_a', scope: SCOPE_CONSTANT)
+    t('ignore_b', scope: SCOPE_CONSTANT)
+  end
 end


### PR DESCRIPTION
- Fixes #441
