### PR TITLE
AstMatcher: Fixes typo for array scopes

### DIFF
--- a/lib/i18n/tasks/scanners/ast_matchers/base_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/base_matcher.rb
@@ -39,7 +39,7 @@ module I18n::Tasks::Scanners::AstMatchers
           # `nil` is returned when a dynamic value is encountered in strict mode. Propagate:
           return nil if str.nil?
         end
-      elsif !@scanner&.config[:strict] && %i[dsym dstr].include?(node.type)
+      elsif !@scanner.config[:strict] && %i[dsym dstr].include?(node.type)
         node.children.map do |child|
           if %i[sym str].include?(child.type)
             child.children[0].to_s
@@ -77,7 +77,7 @@ module I18n::Tasks::Scanners::AstMatchers
           extract_string child
         else
           # ignore dynamic argument in strict mode
-          return nil if config[:strict]
+          return nil if @scanner.config[:strict]
 
           if %i[dsym dstr].include?(child.type) || (child.type == :array && array_flatten)
             extract_string(child, array_join_with: array_join_with)

--- a/spec/fixtures/used_keys/a.rb
+++ b/spec/fixtures/used_keys/a.rb
@@ -19,4 +19,8 @@ class A
     t('ignore_a', scope: SCOPE_CONSTANT)
     t('ignore_b', scope: SCOPE_CONSTANT)
   end
+
+  def issue444
+    t('ignore_array', scope: [:ignore, SCOPE_CONSTANT])
+  end
 end

--- a/spec/used_keys_ruby_spec.rb
+++ b/spec/used_keys_ruby_spec.rb
@@ -5,12 +5,16 @@ require 'spec_helper'
 RSpec.describe 'UsedKeysRuby' do
   let!(:task) { I18n::Tasks::BaseTask.new }
   around do |ex|
-    task.config[:search] = { paths: paths }
+    task.config[:search] = { paths: paths, strict: strict }
     TestCodebase.in_test_app_dir(directory: 'spec/fixtures/used_keys') { ex.run }
   end
 
   let(:paths) {
     %w[a.rb]
+  }
+
+  let(:strict) {
+    true
   }
 
   it '#used_keys - ruby' do
@@ -67,5 +71,16 @@ RSpec.describe 'UsedKeysRuby' do
         ]
       )
     )
+  end
+
+  describe 'strict = false' do
+    let(:strict) { false }
+
+    it '#used_keys - ruby' do
+      used_keys = task.used_tree
+      expect(used_keys.size).to eq(1)
+      leaves = used_keys.leaves.to_a
+      expect(leaves.size).to(eq(4))
+    end
   end
 end


### PR DESCRIPTION
- Fixes #444 and adds tests for it.
