### PR TITLE
Remove `axsls` development dependency

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_dependency 'rails-i18n'
   s.add_dependency 'rainbow', '>= 2.2.2', '< 4.0'
   s.add_dependency 'terminal-table', '>= 1.5.1'
-  s.add_development_dependency 'axlsx', '~> 2.0'
   s.add_development_dependency 'bundler', '~> 2.0', '>= 2.0.1'
   s.add_development_dependency 'overcommit', '~> 0.58.0'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
I believe this functionality was removed in 0.9.24.
https://github.com/glebm/i18n-tasks/blob/main/CHANGES.md#v0924
