### PR TITLE
Remove unnecessary checks from `.gemspec` file

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
     cp $(bundle exec i18n-tasks gem-path)/templates/rspec/i18n_spec.rb spec/
   TEXT
   s.homepage = 'https://github.com/glebm/i18n-tasks'
-  if s.respond_to?(:metadata=)
-    s.metadata = { 'issue_tracker' => 'https://github.com/glebm/i18n-tasks',
-                   'rubygems_mfa_required' => 'true' }
-  end
-  s.required_ruby_version = '>= 2.6', '< 4.0' if s.respond_to?(:required_ruby_version=)
+  s.metadata = { 
+    'issue_tracker' => 'https://github.com/glebm/i18n-tasks',
+    'rubygems_mfa_required' => 'true'
+  }
+  s.required_ruby_version = '>= 2.6', '< 4.0'
 
   s.files = `git ls-files`.split($/)
   s.files -= s.files.grep(%r{^(doc/|\.|spec/)}) + %w[CHANGES.md config/i18n-tasks.yml Gemfile]


### PR DESCRIPTION
`required_ruby_version` was added in 2004: https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#060--2004-06-08.
`metadata` was added in 2012: https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md#060--2004-06-08.

This gem supports Ruby 2.6+, which ships with `rubygems` 3.x which
includes all these features: https://stdgems.org/2.6.10/.
