### PR TITLE
Remove explicit setting of `CI` in GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,6 @@ jobs:
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}
-      CI: 1
       COVERAGE: 1
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is being set by the CI runner since 2020:
https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/
https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables

Feel free to close this if you'd rather keep it explicit. :)
