### PR TITLE
Use Ruby `.transform_values!`

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
@@ -68,8 +68,7 @@ module I18n::Tasks::Scanners
     def comments_to_occurences(path, ast, comments)
       magic_comments = comments.select { |comment| comment.text =~ MAGIC_COMMENT_PREFIX }
       comment_to_node = Parser::Source::Comment.associate_locations(ast, magic_comments).tap do |h|
-        # transform_values is only available in ActiveSupport 4.2+
-        h.each { |k, v| h[k] = v.first }
+        h.transform_values!(&:first)
       end.invert
 
       magic_comments.flat_map do |comment|


### PR DESCRIPTION
This gem supports only Ruby 2.6 and newer. Ruby 2.6 comes with
`.transform_values!`, see:
https://rubyapi.org/2.6/o/hash#method-i-transform_values.
