### PR TITLE
Bug fix: relative_exclude_method_name_paths

### DIFF
--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -30,6 +30,13 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
           warn_deprecated 'Please move relative_roots under search in config/i18n-tasks.yml.'
           c[:search][:relative_roots] = c.delete(:relative_roots)
         end
+
+        if c.dig(:search, :exclude_method_name_paths)
+          warn_deprecated(
+            'Please rename exclude_method_name_paths to relative_exclude_method_name_paths in config/i18n-tasks.yml.'
+          )
+          c[:search][:relative_exclude_method_name_paths] = c[:search].delete(:exclude_method_name_paths)
+        end
       end
     else
       {}.with_indifferent_access

--- a/lib/i18n/tasks/scanners/relative_keys.rb
+++ b/lib/i18n/tasks/scanners/relative_keys.rb
@@ -10,7 +10,7 @@ module I18n
         # @param calling_method [#call, Symbol, String, false, nil]
         # @return [String] absolute version of the key
         def absolute_key(key, path, roots: config[:relative_roots],
-                         exclude_method_name_paths: config[:exclude_method_name_paths],
+                         exclude_method_name_paths: config[:relative_exclude_method_name_paths],
                          calling_method: nil)
           return key unless key.start_with?(DOT)
           fail 'roots argument is required' unless roots.present?

--- a/spec/fixtures/used_keys/app/components/event_component.rb
+++ b/spec/fixtures/used_keys/app/components/event_component.rb
@@ -1,0 +1,6 @@
+class EventComponent < ViewComponent::Base
+  def whatever
+    t(".key")
+    t("absolute_key")
+  end
+end

--- a/spec/fixtures/used_keys/app/controllers/events_controller.rb
+++ b/spec/fixtures/used_keys/app/controllers/events_controller.rb
@@ -1,0 +1,7 @@
+class EventsController < ApplicationController
+  def create
+    t(".relative_key")
+    t("absolute_key")
+    I18n.t("very_absolute_key")
+  end
+end

--- a/spec/used_keys_ruby_spec.rb
+++ b/spec/used_keys_ruby_spec.rb
@@ -10,9 +10,11 @@ RSpec.describe 'UsedKeysRuby' do
     ast_matchers.each do |matcher|
       I18n::Tasks.add_ast_matcher(matcher)
     end
-    task.config[:search] = { paths: paths, strict: strict }
+    task.config[:search] = { paths: paths, strict: strict }.merge(extra_search_config)
     TestCodebase.in_test_app_dir(directory: 'spec/fixtures/used_keys') { ex.run }
   end
+
+  let(:extra_search_config) { {} }
 
   let(:paths) do
     %w[a.rb]
@@ -131,6 +133,98 @@ RSpec.describe 'UsedKeysRuby' do
       expect(used_keys.size).to eq(1)
       leaves = used_keys.leaves.to_a
       expect(leaves.size).to(eq(3))
+    end
+  end
+
+  describe 'relative_roots' do
+    let(:paths) { %w[app/components/event_component.rb app/controllers/events_controller.rb] }
+    let(:extra_search_config) do
+      {
+        relative_roots: %w[app/components app/controllers],
+        relative_exclude_method_name_paths: %w[app/components]
+      }
+    end
+
+    it '#used_keys' do
+      used_keys = task.used_tree
+      expect(used_keys.size).to eq(1)
+      leaves = used_keys.leaves.to_a
+      expect(leaves.size).to(eq(4))
+
+      expect_node_key_data(
+        leaves[0],
+        'event_component.key',
+        occurrences: make_occurrences(
+          [
+            {
+              path: 'app/components/event_component.rb',
+              pos: 62,
+              line_num: 3,
+              line_pos: 4,
+              line: '    t(".key")',
+              raw_key: '.key'
+            }
+          ]
+        )
+      )
+      expect_node_key_data(
+        leaves[1],
+        'absolute_key',
+        occurrences: make_occurrences(
+          [
+            {
+              path: 'app/components/event_component.rb',
+              pos: 76,
+              line_num: 4,
+              line_pos: 4,
+              line: '    t("absolute_key")',
+              raw_key: 'absolute_key'
+            },
+            {
+              path: 'app/controllers/events_controller.rb',
+              pos: 87,
+              line_num: 4,
+              line_pos: 4,
+              line: '    t("absolute_key")',
+              raw_key: 'absolute_key'
+            }
+          ]
+        )
+      )
+
+      expect_node_key_data(
+        leaves[2],
+        'events.create.relative_key',
+        occurrences: make_occurrences(
+          [
+            {
+              path: 'app/controllers/events_controller.rb',
+              pos: 64,
+              line_num: 3,
+              line_pos: 4,
+              line: '    t(".relative_key")',
+              raw_key: '.relative_key'
+            }
+          ]
+        )
+      )
+
+      expect_node_key_data(
+        leaves[3],
+        'very_absolute_key',
+        occurrences: make_occurrences(
+          [
+            {
+              path: 'app/controllers/events_controller.rb',
+              pos: 109,
+              line_num: 5,
+              line_pos: 4,
+              line: '    I18n.t("very_absolute_key")',
+              raw_key: 'very_absolute_key'
+            }
+          ]
+        )
+      )
     end
   end
 end


### PR DESCRIPTION
This option was documented as:
- relative_exclude_method_name_paths
but used as
- exclude_method_name_paths

resulting in unexpected behaviour.
Adds some tests for translations relying on these configurations.

- Fixes #452
