### PR TITLE
Fix 'config' option usage in CLI

### DIFF
--- a/lib/i18n/tasks/cli.rb
+++ b/lib/i18n/tasks/cli.rb
@@ -36,11 +36,12 @@ class I18n::Tasks::CLI
   def run(argv)
     argv.each_with_index do |arg, i|
       if ['--config', '-c'].include?(arg)
-        if File.exist?(argv[i + 1])
-          @config_file = argv[i + 1]
+        _, config_file = argv.slice!(i, 2)
+        if File.exist?(config_file)
+          @config_file = config_file
           break
         else
-          error "Config file doesn't exist: #{argv[i + 1]}", 128
+          error "Config file doesn't exist: #{config_file}", 128
         end
       end
     end


### PR DESCRIPTION
This PR fixes the #409 issue.

As I understand the `config` option is not fully added into the gem. It's used only in the `I18n::Tasks::BaseTask.new` and nowhere else. This change just removes `config` from the arguments. Now all the CLI commands work as expected when providing a custom configuration file.