### PR TITLE
Remove circular requires, fix `Kernel#require` warning

### DIFF
--- a/lib/i18n/tasks/concurrent/cached_value.rb
+++ b/lib/i18n/tasks/concurrent/cached_value.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'i18n/tasks/concurrent/cached_value'
-
 module I18n::Tasks::Concurrent
   # A thread-safe memoized value.
   # The given computation is guaranteed to be invoked at most once.

--- a/lib/i18n/tasks/data/tree/siblings.rb
+++ b/lib/i18n/tasks/data/tree/siblings.rb
@@ -3,7 +3,6 @@
 require 'set'
 require 'i18n/tasks/split_key'
 require 'i18n/tasks/data/tree/nodes'
-require 'i18n/tasks/data/tree/node'
 
 module I18n::Tasks::Data::Tree
   # Siblings represents a subtree sharing a common parent


### PR DESCRIPTION
`I18n::Tasks::Concurrent::CachedValue` was requiring itself - this caused a warning that is avoidable.

Whilst `Siblings` does technically depend on `Node`, `Node` itself has already been required upfront by `I18n::Tasks::Data::FileSystemBase`, so removing this `require` line resolves the warning.

Collectively, these two changes resolved issues for me when loading the gem using Ruby `3.1.2p20`