### PR TITLE
Exclude *.xlsx files by default

### DIFF
--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -30,7 +30,7 @@ module I18n::Tasks
 
     ALWAYS_EXCLUDE = %w[*.jpg *.jpeg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less
                         *.yml *.json *.zip *.tar.gz *.swf *.flv *.mp3 *.wav *.flac *.webm *.mp4 *.ogg *.opus
-                        *.webp *.map].freeze
+                        *.webp *.map *.xlsx].freeze
 
     # Find all keys in the source and return a forest with the keys in absolute form and their occurrences.
     #


### PR DESCRIPTION
If you have Excel files (.xlsx) in your app folder, i18n-tasks will crash, so these should be ignored.