### PR TITLE
Allow dash in locale filenames when merging data

### DIFF
--- a/lib/i18n/tasks/locale_pathname.rb
+++ b/lib/i18n/tasks/locale_pathname.rb
@@ -10,7 +10,7 @@ module I18n::Tasks
       private
 
       def path_locale_re(locale)
-        (@path_locale_res ||= {})[locale] ||= %r{(?<=^|[/.])#{locale}(?=[/.])}
+        (@path_locale_res ||= {})[locale] ||= %r{(?<=^|[/.-])#{locale}(?=[/.])}
       end
     end
   end


### PR DESCRIPTION
A project I'm working on uses dashes in locale filenames (i.e. `user-en.yml` instead of `user.en.yml`), which was causing `i18n-tasks` to not be able to write to the files properly (even after editing the `write` setting in `config/i18n-tasks.yml`).

This adds `-` as a valid character before the `#{locale}` part of filenames.