### PR TITLE
Add pattern option to missing commands

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
             Value. Interpolates: %{value}, %{human_key}, %{key}, %{default}, %{value_or_human_key},
             %{value_or_default_or_human_key}
       desc:
-        add_missing: add missing keys to locale data
+        add_missing: add missing keys to locale data, optionally match a pattern
         check_consistent_interpolations: verify that all translations use correct interpolation variables
         check_normalized: verify that all translation data is normalized
         config: display i18n-tasks configuration
@@ -46,12 +46,12 @@ en:
         gem_path: show path to the gem
         health: is everything OK?
         irb: start REPL session within i18n-tasks context
-        missing: show missing translations
+        missing: show missing translations, optionally match a pattern
         mv: rename/merge the keys in locale data that match the given pattern
         normalize: 'normalize translation data: sort and move to the right files'
         remove_unused: remove unused keys
         rm: remove the keys in locale data that match the given pattern
-        translate_missing: translate missing keys with Google Translate or DeepL Pro
+        translate_missing: translate missing keys with Google Translate or DeepL Pro, optionally match a pattern
         tree_convert: convert tree between formats
         tree_filter: filter tree by key pattern
         tree_merge: merge trees

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,7 +51,8 @@ en:
         normalize: 'normalize translation data: sort and move to the right files'
         remove_unused: remove unused keys
         rm: remove the keys in locale data that match the given pattern
-        translate_missing: translate missing keys with Google Translate or DeepL Pro, optionally match a pattern
+        translate_missing: translate missing keys with Google Translate or DeepL Pro, optionally match
+          a pattern
         tree_convert: convert tree between formats
         tree_filter: filter tree by key pattern
         tree_merge: merge trees

--- a/lib/i18n/tasks/command/commands/missing.rb
+++ b/lib/i18n/tasks/command/commands/missing.rb
@@ -31,7 +31,7 @@ module I18n::Tasks
           forest = i18n.missing_keys(**opt.slice(:locales, :base_locale, :types))
           if opt[:pattern]
             pattern_re = i18n.compile_key_pattern(opt[:pattern])
-            forest = forest.select_keys { |full_key, _node| full_key =~ pattern_re }
+            forest.select_keys! { |full_key, _node| full_key =~ pattern_re }
           end
           print_forest forest, opt, :missing_keys
           :exit1 unless forest.empty?
@@ -46,7 +46,7 @@ module I18n::Tasks
           missing    = i18n.missing_diff_forest opt[:locales], opt[:from]
           if opt[:pattern]
             pattern_re = i18n.compile_key_pattern(opt[:pattern])
-            missing = missing.select_keys { |full_key, _node| full_key =~ pattern_re }
+            missing.select_keys! { |full_key, _node| full_key =~ pattern_re }
           end
           translated = i18n.translate_forest missing, from: opt[:from], backend: opt[:backend].to_sym
           i18n.data.merge! translated
@@ -70,7 +70,7 @@ module I18n::Tasks
                          .set_each_value!(opt[:'nil-value'] ? nil : opt[:value])
             if opt[:pattern]
               pattern_re = i18n.compile_key_pattern(opt[:pattern])
-              forest = forest.select_keys { |full_key, _node| full_key =~ pattern_re }
+              forest.select_keys! { |full_key, _node| full_key =~ pattern_re }
             end
             i18n.data.merge! forest
             added.merge! forest


### PR DESCRIPTION
Closes #468 

This adds the `-p` pattern option to the `missing`, `add-missing`, and `translate-missing` commands.