### PR TITLE
Allow better_html 2.0

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_dependency 'activesupport', '>= 4.0.2'
   s.add_dependency 'ast', '>= 2.1.0'
-  s.add_dependency 'better_html', '~> 1.0'
+  s.add_dependency 'better_html', '>= 1.0', '< 3.0'
   s.add_dependency 'erubi'
   s.add_dependency 'highline', '>= 2.0.0'
   s.add_dependency 'i18n'


### PR DESCRIPTION
Hi,

a new major version of [better_html](https://github.com/Shopify/better-html) has been released

Here it is the changelog: https://github.com/Shopify/better-html/releases/tag/v2.0.0

All specs pass but please check if there is a change that affects i18n-tasks