### PR TITLE
Send DeepL translation requests in multiple batches

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,7 @@ en:
           Setup DeepL Pro API key via DEEPL_AUTH_KEY environment variable or translation.deepl_api_key
           in config/i18n-tasks.yml. Get the key at https://www.deepl.com/pro.
         no_results: DeepL returned no results.
+        specific_target_missing: You must supply a specific variant for the given target language e.g. en-us instead of en.
     google_translate:
       errors:
         no_api_key: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,7 +96,8 @@ en:
           Setup DeepL Pro API key via DEEPL_AUTH_KEY environment variable or translation.deepl_api_key
           in config/i18n-tasks.yml. Get the key at https://www.deepl.com/pro.
         no_results: DeepL returned no results.
-        specific_target_missing: You must supply a specific variant for the given target language e.g. en-us instead of en.
+        specific_target_missing: You must supply a specific variant for the given target language
+          e.g. en-us instead of en.
     google_translate:
       errors:
         no_api_key: >-

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -94,7 +94,8 @@ ru:
           Задайте ключ API DeepL через переменную окружения DEEPL_AUTH_KEY или translation.deepl_api_key
           Получите ключ через https://www.deepl.com/pro.
         no_results: DeepL не дал результатов.
-        specific_target_missing: You must supply a specific variant for the given target language e.g. en-us instead of en.
+        specific_target_missing: You must supply a specific variant for the given target language
+          e.g. en-us instead of en.
     google_translate:
       errors:
         no_api_key: >-

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -94,6 +94,7 @@ ru:
           Задайте ключ API DeepL через переменную окружения DEEPL_AUTH_KEY или translation.deepl_api_key
           Получите ключ через https://www.deepl.com/pro.
         no_results: DeepL не дал результатов.
+        specific_target_missing: You must supply a specific variant for the given target language e.g. en-us instead of en.
     google_translate:
       errors:
         no_api_key: >-

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -74,13 +74,12 @@ module I18n::Tasks::Translators
       locale.to_s.split('-', 2).first.upcase
     end
 
-    # Convert 'es-ES' to 'ES' but skip specific locales
-    # This and the above should probably be done by the deepl gem
+    # Convert 'es-ES' to 'ES' but warn about locales requiring a specific variant
     def to_deepl_target_locale(locale)
       loc, sub = locale.to_s.split('-')
       if SPECIFIC_TARGETS.include?(loc)
-        fail ::I18n::Tasks::CommandError, I18n.t('i18n_tasks.deepl_translate.errors.specific_target_missing') unless sub
-
+        # Must see how the deepl api evolves, so this could be an error in the future
+        @i18n_tasks.warn_deprecated I18n.t('i18n_tasks.deepl_translate.errors.specific_target_missing') unless sub
         locale.to_s.upcase
       else
         loc.upcase

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -6,12 +6,14 @@ require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
   nil_value_test = ['nil-value-key', nil, nil]
-  text_test      = ['key', "Hello, %{user} O'Neill! How are you?", "Hola, %{user} ¡O'Neill! Como estas?"]
-  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎"]
+  text_test      = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Cómo estás?"]
   html_test_plrl = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
   array_test     = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   fixnum_test    = ['numeric-key', 1, 1]
   ref_key_test   = ['ref-key', :reference, :reference]
+  # this test fails atm due to moving of the bold tag =>  "Hola, <b>%{user} </b> gran O'neill ❤︎ "
+  # it could be a bug, but the api also allows to ignore certain tags and there is the new html-markup version which could be used to
+  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎ "]
 
   describe 'real world test' do
     delegate :i18n_task, :in_test_app_dir, :run_cmd, to: :TestCodebase
@@ -53,13 +55,13 @@ RSpec.describe 'DeepL Translation' do
 
           run_cmd 'translate-missing', '--backend=deepl'
           expect(task.t('common.hello', 'es')).to eq(text_test[2])
-          expect(task.t('common.hello_html', 'es')).to eq(html_test[2])
           expect(task.t('common.hello_plural_html.one', 'es')).to eq(html_test_plrl[2])
           expect(task.t('common.array_key', 'es')).to eq(array_test[2])
           expect(task.t('common.nil-value-key', 'es')).to eq(nil_value_test[2])
           expect(task.t('common.fixnum-key', 'es')).to eq(fixnum_test[2])
           expect(task.t('common.ref-key', 'es')).to eq(ref_key_test[2])
           expect(task.t('common.a', 'es')).to eq('λ')
+          expect(task.t('common.hello_html', 'es')).to eq(html_test[2])
         end
       end
     end


### PR DESCRIPTION
I did get an unspecified error when sending 2000+ translations to deepl. The author of the deepl gem has relased a new version where he added an specific error when hitting a limit.

This PR also handles deepl's target locale requirement for EN and PT which need their sub-version defined e.g. EN-US.
This can be a potential 'breaking' change for users still using EN as plain target, as i added an error for this case. See https://www.deepl.com/de/docs-api/translate-text/translate-text/ with their target_lang description