### PR TITLE
DeepL: Allow formality option to be configured through config.

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -35,7 +35,9 @@ module I18n::Tasks::Translators
     end
 
     def options_for_translate_values(**options)
-      { ignore_tags: %w[i18n] }.merge(options)
+      extra_options = @i18n_tasks.translation_config[:deepl_options]&.symbolize_keys || {}
+
+      extra_options.merge({ ignore_tags: %w[i18n] }).merge(options)
     end
 
     def options_for_html

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -110,7 +110,9 @@ search:
 #   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
 #   # deepl_host: "https://api.deepl.com"
 #   # deepl_version: "v2"
-
+#   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
+#   deepl_options:
+#     formality: prefer_less
 ## Do not consider these keys missing:
 # ignore_missing:
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'


### PR DESCRIPTION
DeepL has the concept of `formality for certain languages (https://www.deepl.com/docs-api/translate-text/translate-text/). 

e.g:

* **English**: How much time can you commit to playing?
* **German, formal**: Wie viel Zeit können Sie zum Spielen aufwenden?
* **German, informal**: Wie viel Zeit kannst du zum Spielen aufwenden?

However, the DeepL gem does not allow this to be configured globally, only on a per-call basis to the `DeepL.translate` call. I looked, but couldn't find a way to alter this in config.

By adding a `deepl_options:` key to the configuration, we allow some of these keys to be overridden (although keeping `extra_options` first in the merge chain means that explicitly set `ignore_tags` remains forced).

Had a look at the spec for the `DeeplTranslator` but couldn't see an easy way to assert this - feel free to let me know where I should add the spec!