### PR TITLE
move instance variable assignment out of setup in minitest template

### DIFF
--- a/templates/minitest/i18n_test.rb
+++ b/templates/minitest/i18n_test.rb
@@ -5,18 +5,18 @@ require 'i18n/tasks'
 class I18nTest < ActiveSupport::TestCase
   def setup
     @i18n = I18n::Tasks::BaseTask.new
-    @missing_keys = @i18n.missing_keys
-    @unused_keys = @i18n.unused_keys
   end
 
   def test_no_missing_keys
-    assert_empty @missing_keys,
-                 "Missing #{@missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
+    missing_keys = @i18n.missing_keys
+    assert_empty missing_keys,
+                 "Missing #{missing_keys.leaves.count} i18n keys, run `i18n-tasks missing' to show them"
   end
 
   def test_no_unused_keys
-    assert_empty @unused_keys,
-                 "#{@unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
+    unused_keys = @i18n.unused_keys
+    assert_empty unused_keys,
+                 "#{unused_keys.leaves.count} unused i18n keys, run `i18n-tasks unused' to show them"
   end
 
   def test_files_are_normalized


### PR DESCRIPTION
Hello 👋 

I have a suggestion that concerns the minitest template.

Currently the template has a `setup` block where two instance variables are defined, which are only used in single tests.
In that case it makes sense to not have them in `setup` because this block is executed before every test.

http://docs.seattlerb.org/minitest/Minitest/Test/LifecycleHooks.html#method-i-setup