### PR TITLE
Ignore non-html interpolations in DeepL Translator

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -37,7 +37,7 @@ module I18n::Tasks::Translators
     def options_for_translate_values(**options)
       extra_options = @i18n_tasks.translation_config[:deepl_options]&.symbolize_keys || {}
 
-      extra_options.merge({ ignore_tags: %w[i18n] }).merge(options)
+      extra_options.merge({ ignore_tags: %w[i18n], tag_handling: 'xml' }).merge(options)
     end
 
     def options_for_html

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -6,14 +6,14 @@ require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
   nil_value_test = ['nil-value-key', nil, nil]
-  text_test      = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Cómo estás?"]
+  text_test      = ['key', "Hello, %{name} O'Neill! How are you?", "¡Hola, %{name} O'Neill! ¿Qué tal estás?", "Dobrý den, %{name} O'Neill! Jak se máš?"]
   html_test_plrl = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
   array_test     = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   fixnum_test    = ['numeric-key', 1, 1]
   ref_key_test   = ['ref-key', :reference, :reference]
   # this test fails atm due to moving of the bold tag =>  "Hola, <b>%{user} </b> gran O'neill ❤︎ "
   # it could be a bug, but the api also allows to ignore certain tags and there is the new html-markup version which could be used to
-  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎ "]
+  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎"]
 
   describe 'real world test' do
     delegate :i18n_task, :in_test_app_dir, :run_cmd, to: :TestCodebase
@@ -53,7 +53,13 @@ RSpec.describe 'DeepL Translation' do
                                         }
                                       })
 
+          task.data[:cs] = build_tree('cs' => {
+            'common' => {
+              'a' => 'λ'
+            }
+          })
           run_cmd 'translate-missing', '--backend=deepl'
+          expect(task.t('common.hello', 'cs')).to eq(text_test[3])
           expect(task.t('common.hello', 'es')).to eq(text_test[2])
           expect(task.t('common.hello_plural_html.one', 'es')).to eq(html_test_plrl[2])
           expect(task.t('common.array_key', 'es')).to eq(array_test[2])


### PR DESCRIPTION
As described in [DeepL xml docs](https://www.deepl.com/docs-api/xml) `ignore_tags` can only be used when `tag_handling=xml`

It worked in the Spanish example, because it is not translating user in this context.

![Screenshot 2023-01-23 at 18 34 35](https://user-images.githubusercontent.com/79217155/214098609-ed51d970-e2d4-4408-bc37-df2e1da2b78c.png)

We discovered this bug by translating a bigger project and it happened to more than the half of our translations.
As you can see we added regression test. Enabling `xml` does  work in our code base without any side effects. 