### PR TITLE
GitHub CI: `gem update --system`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ env.CC_TEST_REPORTER_ID && startsWith(matrix.ruby-version, '3.0') && github.ref == 'refs/heads/main' }}
         run: echo UPLOAD_COVERAGE=1 >> $GITHUB_ENV
       - name: Install dependencies
-        run: bundle install
+        run: gem update --system && bundle install
       - name: Run tests
         if: ${{ !env.UPLOAD_COVERAGE }}
         run: bundle exec rake


### PR DESCRIPTION
Fixes the following warning:
> Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`