### PR TITLE
Update grep_keys to work in Ruby 3+

### DIFF
--- a/lib/i18n/tasks/data/tree/traversal.rb
+++ b/lib/i18n/tasks/data/tree/traversal.rb
@@ -161,7 +161,7 @@ module I18n::Tasks
       end
 
       def grep_keys(match, opts = {})
-        select_keys(opts) do |full_key, _node|
+        select_keys(**opts) do |full_key, _node|
           match === full_key # rubocop:disable Style/CaseEquality
         end
       end

--- a/spec/locale_tree/traversal_spec.rb
+++ b/spec/locale_tree/traversal_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+RSpec.describe I18n::Tasks::Data::Tree::Traversal do
+  delegate :i18n_task, to: :TestCodebase
+
+  describe '#grep_keys' do
+    it 'returns Siblings' do
+      expect(i18n_task.data['en'].grep_keys(/key/)).to be_a(I18n::Tasks::Data::Tree::Siblings)
+    end
+  end
+
+  # --- setup ---
+  before(:each) do
+    TestCodebase.setup fixtures_contents
+  end
+
+  after do
+    TestCodebase.teardown
+  end
+end


### PR DESCRIPTION
Pass argument `opts` as keyword arguments to `select_keys`. Fixes issue #491