### PR TITLE
Strip trailing space added by older libyaml for nil array values

### DIFF
--- a/lib/i18n/tasks/data/adapter/yaml_adapter.rb
+++ b/lib/i18n/tasks/data/adapter/yaml_adapter.rb
@@ -6,6 +6,7 @@ module I18n::Tasks
     module Adapter
       module YamlAdapter
         EMOJI_REGEX = /\\u[\da-f]{8}/i.freeze
+        TRAILING_SPACE_REGEX = / $/.freeze
 
         class << self
           # @return [Hash] locale tree
@@ -20,12 +21,17 @@ module I18n::Tasks
 
           # @return [String]
           def dump(tree, options)
-            restore_emojis(tree.to_yaml(options || {}))
+            strip_trailing_spaces(restore_emojis(tree.to_yaml(options || {})))
           end
 
           # @return [String]
           def restore_emojis(yaml)
             yaml.gsub(EMOJI_REGEX) { |m| [m[-8..].to_i(16)].pack('U') }
+          end
+
+          # @return [String]
+          def strip_trailing_spaces(yaml)
+            yaml.gsub(TRAILING_SPACE_REGEX, '')
           end
         end
       end

--- a/spec/fixtures/app/views/index.html.slim
+++ b/spec/fixtures/app/views/index.html.slim
@@ -36,6 +36,7 @@ p = Spree.t 'not_a_key'
 = t 'reference-missing-target.a'
 
 = t 'emoji.smile'
+= t('array.with_nil').compact.join(" ")
 
 p = t 'missing_key_ending_in_colon.key:'
 p = t(:ignored_in_strict_mode, scope: [:search, params[:action]]), query: params[:q]

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -251,6 +251,26 @@ RSpec.describe 'i18n-tasks' do
         expect(en_yml_data[:en][:emoji][:smile].value).to eq('😀')
       end
     end
+
+    it 'strips trailing space left by older libyaml' do
+      in_test_app_dir do
+        run_cmd 'normalize'
+
+        result = File.readlines('config/locales/es.yml')[1..6].join
+
+        aggregate_failures do
+          expect(result).to match(/  -$/)
+          expect(result).to eq <<~YAML
+            es:
+              array:
+                with_nil:
+                -
+                - foo ES_TEXT
+                - bar ES_TEXT
+          YAML
+        end
+      end
+    end
   end
 
   describe 'add_missing' do
@@ -386,6 +406,7 @@ RSpec.describe 'i18n-tasks' do
           }
         },
         'emoji' => { 'smile' => '😀' },
+        'array' => { 'with_nil' => [nil, "foo #{v}", "bar #{v}"] },
         'numeric' => { 'a' => v_num },
         'plural' => { 'a' => { 'one' => v, 'other' => "%{count} #{v}s" } },
         'scoped' => { 'x' => v },


### PR DESCRIPTION
This makes normalization work consistently, regardless of the libyaml version used by psych.

This fixes https://github.com/glebm/i18n-tasks/issues/355
