### PR TITLE
chore: add Dependabot for Actions and Gems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Noticed a few of the Actions were behind, so thought Dependabot would be better than a few on-off PRs