### PR TITLE
ci: add Ruby 3.2 to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.2.0', '3.1.0', '3.0.1', '2.7.3', '2.6.7']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7', '2.6']
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1.0', '3.0.1', '2.7.3', '2.6.7']
+        ruby-version: ['3.2.0', '3.1.0', '3.0.1', '2.7.3', '2.6.7']
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}


### PR DESCRIPTION
Wasn't sure about the minor version pinning, but I kept the same style as the others