### PR TITLE
chore: cleanup autofixable rubocop lints

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,13 +15,6 @@ Gemspec/DevelopmentDependencies:
 
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
-# SupportedStyles: leading, trailing
-Layout/LineContinuationLeadingSpace:
-  Exclude:
-    - 'lib/i18n/tasks/references.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
 # SupportedStyles: space, no_space
 Layout/LineContinuationSpacing:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,13 +35,6 @@ Style/RedundantInitialize:
   Exclude:
     - 'lib/i18n/tasks/cli.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: WordRegex.
-# SupportedStyles: percent, brackets
-Style/WordArray:
-  EnforcedStyle: percent
-  MinSize: 3
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: forbid_for_all_comparison_operators, forbid_for_equality_operators_only, require_for_all_comparison_operators, require_for_equality_operators_only

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,17 +29,6 @@ Style/HashTransformValues:
   Exclude:
     - 'lib/i18n/tasks/data/tree/traversal.rb'
 
-# This cop supports safe autocorrection (--autocorrect).
-Style/RedundantConstantBase:
-  Exclude:
-    - 'Rakefile'
-    - 'spec/i18n_tasks_spec.rb'
-    - 'spec/locale_pathname_spec.rb'
-    - 'spec/missing_keys_spec.rb'
-    - 'spec/plural_keys_spec.rb'
-    - 'spec/references_spec.rb'
-    - 'spec/split_key_spec.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowComments.
 Style/RedundantInitialize:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -36,11 +36,6 @@ Style/RedundantInitialize:
     - 'lib/i18n/tasks/cli.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-Style/RedundantRegexpEscape:
-  Exclude:
-    - 'lib/i18n/tasks/scanners/pattern_scanner.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: WordRegex.
 # SupportedStyles: percent, brackets
 Style/WordArray:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,11 +14,6 @@ Gemspec/DevelopmentDependencies:
     - 'i18n-tasks.gemspec'
 
 # This cop supports safe autocorrection (--autocorrect).
-Layout/ElseAlignment:
-  Exclude:
-    - 'lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyleAlignWith, Severity.
 # SupportedStylesAlignWith: keyword, variable, start_of_line
 Layout/EndAlignment:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,12 +14,6 @@ Gemspec/DevelopmentDependencies:
     - 'i18n-tasks.gemspec'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Exclude:
-    - 'lib/i18n/tasks/command/commands/missing.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Width, AllowedPatterns.
 Layout/IndentationWidth:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,16 +14,6 @@ Gemspec/DevelopmentDependencies:
     - 'i18n-tasks.gemspec'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/LineContinuationSpacing:
-  Exclude:
-    - 'lib/i18n/tasks/configuration.rb'
-    - 'lib/i18n/tasks/references.rb'
-    - 'lib/i18n/tasks/reports/base.rb'
-    - 'lib/i18n/tasks/reports/terminal.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
 # SupportedStylesForExponentOperator: space, no_space
 Layout/SpaceAroundOperators:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,13 +30,6 @@ Style/HashTransformValues:
     - 'lib/i18n/tasks/data/tree/traversal.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle, MinBodyLength.
-# SupportedStyles: skip_modifier_ifs, always
-Style/Next:
-  Exclude:
-    - 'lib/i18n/tasks/cli.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 Style/RedundantConstantBase:
   Exclude:
     - 'Rakefile'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,13 +14,6 @@ Gemspec/DevelopmentDependencies:
     - 'i18n-tasks.gemspec'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyleAlignWith, Severity.
-# SupportedStylesAlignWith: keyword, variable, start_of_line
-Layout/EndAlignment:
-  Exclude:
-    - 'lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
 Layout/ExtraSpacing:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,12 +14,6 @@ Gemspec/DevelopmentDependencies:
     - 'i18n-tasks.gemspec'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Width, AllowedPatterns.
-Layout/IndentationWidth:
-  Exclude:
-    - 'lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: leading, trailing
 Layout/LineContinuationLeadingSpace:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,13 +13,6 @@ Gemspec/DevelopmentDependencies:
   Exclude:
     - 'i18n-tasks.gemspec'
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
-# SupportedStylesForExponentOperator: space, no_space
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'lib/i18n/tasks/translators/deepl_translator.rb'
-
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSafeAssignment.
 Lint/AssignmentInCondition:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: Severity, Include.
-# Include: **/*.gemspec
-Gemspec/DeprecatedAttributeAssignment:
-  Exclude:
-    - 'i18n-tasks.gemspec'
-
 # Configuration parameters: EnforcedStyle, AllowedGems, Include.
 # SupportedStyles: Gemfile, gems.rb, gemspec
 # Include: **/*.gemspec, **/Gemfile, **/gems.rb

--- a/Rakefile
+++ b/Rakefile
@@ -9,5 +9,5 @@ task :irb do
   # $: << File.expand_path('lib', __FILE__)
   require 'i18n/tasks'
   require 'i18n/tasks/commands'
-  ::I18n::Tasks::Commands.new(::I18n::Tasks::BaseTask.new).irb
+  I18n::Tasks::Commands.new(I18n::Tasks::BaseTask.new).irb
 end

--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.files = `git ls-files`.split($/)
   s.files -= s.files.grep(%r{^(doc/|\.|spec/)}) + %w[CHANGES.md config/i18n-tasks.yml Gemfile]
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[i18n-tasks.cmd]
-  s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
   s.add_dependency 'activesupport', '>= 4.0.2'

--- a/lib/i18n/tasks/cli.rb
+++ b/lib/i18n/tasks/cli.rb
@@ -35,14 +35,14 @@ class I18n::Tasks::CLI
 
   def run(argv)
     argv.each_with_index do |arg, i|
-      if ['--config', '-c'].include?(arg)
-        _, config_file = argv.slice!(i, 2)
-        if File.exist?(config_file)
-          @config_file = config_file
-          break
-        else
-          error "Config file doesn't exist: #{config_file}", 128
-        end
+      next unless ['--config', '-c'].include?(arg)
+
+      _, config_file = argv.slice!(i, 2)
+      if File.exist?(config_file)
+        @config_file = config_file
+        break
+      else
+        error "Config file doesn't exist: #{config_file}", 128
       end
     end
 

--- a/lib/i18n/tasks/command/commands/missing.rb
+++ b/lib/i18n/tasks/command/commands/missing.rb
@@ -43,7 +43,7 @@ module I18n::Tasks
             args: [:locales, :locale_to_translate_from, arg(:out_format).from(1), :translation_backend, :pattern]
 
         def translate_missing(opt = {})
-          missing    = i18n.missing_diff_forest opt[:locales], opt[:from]
+          missing = i18n.missing_diff_forest opt[:locales], opt[:from]
           if opt[:pattern]
             pattern_re = i18n.compile_key_pattern(opt[:pattern])
             missing.select_keys! { |full_key, _node| full_key =~ pattern_re }

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -87,7 +87,7 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
       valid_locales = Dir[File.join(I18n::Tasks.gem_path, 'config', 'locales', '*.yml')]
                       .map { |f| File.basename(f, '.yml') }
       unless valid_locales.include?(internal_locale)
-        log_warn "invalid internal_locale #{internal_locale.inspect}. "\
+        log_warn "invalid internal_locale #{internal_locale.inspect}. " \
                  "Available internal locales: #{valid_locales * ', '}."
         internal_locale = DEFAULTS[:internal_locale].to_s
       end

--- a/lib/i18n/tasks/references.rb
+++ b/lib/i18n/tasks/references.rb
@@ -90,8 +90,8 @@ module I18n::Tasks
           on_leaves_merge: lambda do |node, other|
             if node.value != other.value
               log_warn(
-                'Conflicting references: '\
-                "#{node.full_key(root: false)} ⮕ #{node.value} in #{node.data[:locale]}, "\
+                'Conflicting references: ' \
+                "#{node.full_key(root: false)} ⮕ #{node.value} in #{node.data[:locale]}, " \
                 "but ⮕ #{other.value} in #{other.data[:locale]}"
               )
             end

--- a/lib/i18n/tasks/references.rb
+++ b/lib/i18n/tasks/references.rb
@@ -91,8 +91,8 @@ module I18n::Tasks
             if node.value != other.value
               log_warn(
                 'Conflicting references: '\
-                "#{node.full_key(root: false)} ⮕ #{node.value} in #{node.data[:locale]},"\
-                " but ⮕ #{other.value} in #{other.data[:locale]}"
+                "#{node.full_key(root: false)} ⮕ #{node.value} in #{node.data[:locale]}, "\
+                "but ⮕ #{other.value} in #{other.data[:locale]}"
               )
             end
           end

--- a/lib/i18n/tasks/reports/base.rb
+++ b/lib/i18n/tasks/reports/base.rb
@@ -36,7 +36,7 @@ module I18n::Tasks::Reports
 
     def used_title(keys_nodes, filter)
       used_n = keys_nodes.map { |_k, node| node.data[:occurrences].size }.reduce(:+).to_i
-      "#{keys_nodes.size} key#{'s' if keys_nodes.size != 1}#{" matching '#{filter}'" if filter}"\
+      "#{keys_nodes.size} key#{'s' if keys_nodes.size != 1}#{" matching '#{filter}'" if filter}" \
         "#{" (#{used_n} usage#{'s' if used_n != 1})" if used_n.positive?}"
     end
 

--- a/lib/i18n/tasks/reports/terminal.rb
+++ b/lib/i18n/tasks/reports/terminal.rb
@@ -112,7 +112,7 @@ module I18n
           when :missing_plural
             leaf[:data][:missing_keys].join(', ')
           else
-            "#{Rainbow(leaf[:data][:missing_diff_locale]).cyan} "\
+            "#{Rainbow(leaf[:data][:missing_diff_locale]).cyan} " \
             "#{format_value(leaf[:value].is_a?(String) ? leaf[:value].strip : leaf[:value])}"
           end
         end

--- a/lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb
@@ -82,7 +82,7 @@ module I18n::Tasks::Scanners::AstMatchers
                         extract_hash(default_arg_node.children[1])
                       else
                         extract_string(default_arg_node.children[1])
-        end
+                      end
       end
 
       [key, default_arg]

--- a/lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/message_receivers_matcher.rb
@@ -79,9 +79,9 @@ module I18n::Tasks::Scanners::AstMatchers
       end
       if default_arg_node = extract_hash_pair(node, 'default')
         default_arg = if default_arg_node.children[1]&.type == :hash
-          extract_hash(default_arg_node.children[1])
-        else
-          extract_string(default_arg_node.children[1])
+                        extract_hash(default_arg_node.children[1])
+                      else
+                        extract_string(default_arg_node.children[1])
         end
       end
 

--- a/lib/i18n/tasks/scanners/pattern_scanner.rb
+++ b/lib/i18n/tasks/scanners/pattern_scanner.rb
@@ -12,7 +12,7 @@ module I18n::Tasks::Scanners
     include OccurrenceFromPosition
     include RubyKeyLiterals
 
-    TRANSLATE_CALL_RE = /(?<=^|[^\w'\-.]|[^\w'\-]I18n\.|I18n\.)t(?:!|ranslate!?)?/.freeze
+    TRANSLATE_CALL_RE = /(?<=^|[^\w'\-.]|[^\w'-]I18n\.|I18n\.)t(?:!|ranslate!?)?/.freeze
     IGNORE_LINES = {
       'coffee' => /^\s*#(?!\si18n-tasks-use)/,
       'erb' => /^\s*<%\s*#(?!\si18n-tasks-use)/,

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -7,7 +7,7 @@ module I18n::Tasks::Translators
     # max allowed texts per request
     BATCH_SIZE = 50
     # those languages must be specified with their sub-kind e.g en-us
-    SPECIFIC_TARGETS = ['en', 'pt'].freeze
+    SPECIFIC_TARGETS = %w[en pt].freeze
 
     def initialize(*)
       begin

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -7,7 +7,7 @@ module I18n::Tasks::Translators
     # max allowed texts per request
     BATCH_SIZE = 50
     # those languages must be specified with their sub-kind e.g en-us
-    SPECIFIC_TARGETS= ['en', 'pt'].freeze
+    SPECIFIC_TARGETS = ['en', 'pt'].freeze
 
     def initialize(*)
       begin

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe 'i18n-tasks' do
     it 'removes unused' do
       in_test_app_dir do
         t      = i18n_task
-        unused = expected_unused_keys.map { |k| ::I18n::Tasks::SplitKey.split_key(k, 2)[1] }
+        unused = expected_unused_keys.map { |k| I18n::Tasks::SplitKey.split_key(k, 2)[1] }
         unused.each do |key|
           expect(t.key_value?(key, :en)).to be true
           expect(t.key_value?(key, :es)).to be true
@@ -182,7 +182,7 @@ RSpec.describe 'i18n-tasks' do
     it 'removes unused (--keep-order)' do
       in_test_app_dir do
         t      = i18n_task
-        unused = expected_unused_keys.map { |k| ::I18n::Tasks::SplitKey.split_key(k, 2)[1] }
+        unused = expected_unused_keys.map { |k| I18n::Tasks::SplitKey.split_key(k, 2)[1] }
         unused.each do |key|
           expect(t.key_value?(key, :en)).to be true
           expect(t.key_value?(key, :es)).to be true
@@ -200,7 +200,7 @@ RSpec.describe 'i18n-tasks' do
 
     it 'does not sort the keys (--keep-order)' do
       in_test_app_dir do
-        unused_keys = expected_unused_keys.map { |k| ::I18n::Tasks::SplitKey.split_key(k, 2)[1] }
+        unused_keys = expected_unused_keys.map { |k| I18n::Tasks::SplitKey.split_key(k, 2)[1] }
         initial_keys = i18n_task.data['en'].select_keys do |k, _node|
           unused_keys.none? { |unused_key| k.include?(unused_key) }
         end

--- a/spec/locale_pathname_spec.rb
+++ b/spec/locale_pathname_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe 'LocalePathname' do
   context '#replace_locale' do
     def replace_locale(path, from, to)
-      ::I18n::Tasks::LocalePathname.replace_locale(path, from, to)
+      I18n::Tasks::LocalePathname.replace_locale(path, from, to)
     end
 
     it 'es.yml' do

--- a/spec/missing_keys_spec.rb
+++ b/spec/missing_keys_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe 'MissingKeys' do
   describe '#required_plural_keys_for_locale(locale)' do
-    let(:task) { ::I18n::Tasks::BaseTask.new }
+    let(:task) { I18n::Tasks::BaseTask.new }
 
     def configuration_from(locale)
       {

--- a/spec/plural_keys_spec.rb
+++ b/spec/plural_keys_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Plural keys' do
-  let(:task) { ::I18n::Tasks::BaseTask.new }
+  let(:task) { I18n::Tasks::BaseTask.new }
 
   let(:base_keys) do
     {

--- a/spec/references_spec.rb
+++ b/spec/references_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe 'Reference keys' do
-  let(:task) { ::I18n::Tasks::BaseTask.new }
+  let(:task) { I18n::Tasks::BaseTask.new }
 
   describe '#process_references' do
     it 'resolves plain references' do

--- a/spec/split_key_spec.rb
+++ b/spec/split_key_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe 'SplitKey' do
-  include ::I18n::Tasks::SplitKey
+  include I18n::Tasks::SplitKey
 
   [
     # rubocop:disable Lint/InterpolationCheck


### PR DESCRIPTION
Took a pass for the ones marked as "safe autocorrect" and did them as separate commits