### PR TITLE
chore: disable CodeClimate Rubocop

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,7 +8,7 @@ engines:
   fixme:
     enabled: true
   rubocop:
-    enabled: true
+    enabled: false
 ratings:
   paths:
   - "**.rb"


### PR DESCRIPTION
Rubocop is now running as part of the actions, and appears that the version on CodeClimate has been failing for a bit https://codeclimate.com/github/glebm/i18n-tasks/builds/176