### PR TITLE
ci: use floating v4 tag for codeclimate action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
         if: ${{ !env.UPLOAD_COVERAGE }}
         run: bundle exec rake
       - name: Run tests and upload coverage
-        uses: paambaati/codeclimate-action@v4.0.0
+        uses: paambaati/codeclimate-action@v4
         if: ${{ env.UPLOAD_COVERAGE }}
         with:
           coverageCommand: bundle exec rake


### PR DESCRIPTION
Should reduce some of the Dependabot noise outside of major releases