### PR TITLE
Bump minimum `parser` version

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'erubi'
   s.add_dependency 'highline', '>= 2.0.0'
   s.add_dependency 'i18n'
-  s.add_dependency 'parser', '>= 2.2.3.0'
+  s.add_dependency 'parser', '>= 3.2.2.1'
   s.add_dependency 'rails-i18n'
   s.add_dependency 'rainbow', '>= 2.2.2', '< 4.0'
   s.add_dependency 'terminal-table', '>= 1.5.1'


### PR DESCRIPTION
This is the first version which includes the fix (https://github.com/whitequark/parser/pull/924) to a performance issue (https://github.com/whitequark/parser/issues/918) first introduced in 3.0.3.0 (https://github.com/whitequark/parser/commit/547d731adef312dd781472c600d38c5823635ac0)

Fixes #407