### PR TITLE
Fix Find.find typo in config template

### DIFF
--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -52,7 +52,7 @@ data:
 
 # Find translate calls
 search:
-  ## Paths or `File.find` patterns to search in:
+  ## Paths or `Find.find` patterns to search in:
   # paths:
   #  - app/
 

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -13,7 +13,7 @@ data:
   ## Provide a custom adapter:
   # adapter: I18n::Tasks::Data::FileSystem
 
-  # Locale files or `File.find` patterns where translations are read from:
+  # Locale files or `Find.find` patterns where translations are read from:
   read:
     ## Default:
     # - config/locales/%{locale}.yml


### PR DESCRIPTION
Fix that the config template mentions `File.find` instead of `Find.find`. `Find.find` is used here: https://github.com/glebm/i18n-tasks/blob/main/lib/i18n/tasks/scanners/files/file_finder.rb#L38