### PR TITLE
Support partially dynamic segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ A special syntax similar to file glob patterns is used throughout i18n-tasks to 
 |:------------:|:----------------------------------------------------------|
 |      `*`     | matches everything                                        |
 |      `:`     | matches a single key                                      |
+|      `*:`    | matches part of a single key                              |
 |   `{a, b.c}` | match any in set, can use `:` and `*`, match is captured  |
 
 Example of usage:

--- a/lib/i18n/tasks/key_pattern_matching.rb
+++ b/lib/i18n/tasks/key_pattern_matching.rb
@@ -21,6 +21,7 @@ module I18n::Tasks::KeyPatternMatching
   # In patterns:
   #      *     is like .* in regexs
   #      :     matches a single key
+  #      *:    matches part of a single key, similar to a lazy regex
   #   { a, b.c } match any in set, can use : and *, match is captured
   def compile_key_pattern(key_pattern)
     return key_pattern if key_pattern.is_a?(Regexp)
@@ -31,6 +32,7 @@ module I18n::Tasks::KeyPatternMatching
   def key_pattern_re_body(key_pattern)
     key_pattern
       .gsub(/\./, '\.')
+      .gsub(/\*:/, '[^.]+?')
       .gsub(/\*/, '.*')
       .gsub(/:/, '(?<=^|\.)[^.]+?(?=\.|$)')
       .gsub(/\{(.*?)}/) { "(#{Regexp.last_match(1).strip.gsub(/\s*,\s*/, '|')})" }

--- a/lib/i18n/tasks/key_pattern_matching.rb
+++ b/lib/i18n/tasks/key_pattern_matching.rb
@@ -21,7 +21,7 @@ module I18n::Tasks::KeyPatternMatching
   # In patterns:
   #      *     is like .* in regexs
   #      :     matches a single key
-  #      *:    matches part of a single key, similar to a lazy regex
+  #      *:    matches part of a single key, equivalent to `[^.]+?` regex
   #   { a, b.c } match any in set, can use : and *, match is captured
   def compile_key_pattern(key_pattern)
     return key_pattern if key_pattern.is_a?(Regexp)

--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -142,7 +142,7 @@ module I18n::Tasks
 
     # keys in the source that end with a ., e.g. t("category.#{ cat.i18n_key }") or t("category." + category.key)
     # @param [String] replacement for interpolated values.
-    def expr_key_re(replacement: ':')
+    def expr_key_re(replacement: '*:')
       @expr_key_re ||= begin
         # disallow patterns with no keys
         ignore_pattern_re = /\A[.#{replacement}]*\z/

--- a/spec/key_pattern_matching_spec.rb
+++ b/spec/key_pattern_matching_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe 'Key pattern' do
       end
     end
 
+    describe '*:' do
+      it 'as suffix' do
+        expect('a.b.pre-*:-post').to match_key 'a.b.pre-c-post'
+        expect('a.b.pre-*:-post').not_to match_key 'a.b.pre-c.-post'
+      end
+
+      it 'as prefix' do
+        expect('pre-*:-post.b.c').to match_key 'pre-a-post.b.c'
+        expect('pre-*:-post.b.c').not_to match_key 'pre-.a-post.b.c'
+      end
+
+      it 'as infix' do
+        expect('a.pre-*:-post.c').to match_key 'a.pre-b-post.c'
+        expect('a.pre-*:-post.c').not_to match_key 'a.pre-b.-post.c'
+      end
+    end
+
     describe '{sets}' do
       it 'matches' do
         p = 'a.{x,y}.b'


### PR DESCRIPTION
### What it is

Adds matching for dynamic portions of a segment. This is in addition to the current dynamic matching which matches only entire segments.

### Why

Currently, "cats.tenderlove-bio.name" would be marked unused even if the source code contains  `t "cats.#{cat}-bio.name"`.

Closes #508

### How

The library uses two special characters in regex matches right now: `*` and `:`. I combined these characters to create a "lazy match" similar the the way you combine `.+` and `?` to lazily match in standard regular expressions.

I created tests which verify that the partial match is only done in a single segment, rather than matching across segments.

Since there isn't currently a way to change which replacement string is used from `":"`, I changed the default value to the new `"*:"`.

### Questions

- What are the repercussions of changing the default replacement value?
  - In particular, I don't know if this has any negative repercussions on [this line](https://github.com/brandoncc/i18n-tasks/blob/da7d6df96cc5510cd52aa8134995bc2161950551/lib/i18n/tasks/used_keys.rb#L148) and other lines that use this variable.
- Is this likely to have any negative effects on existing users of the library?
  - I think it might be a good idea to introduce an "opt-in" option in the configuration so that existing users don't see a change in behavior. This option could become the default in a future version. Alternatively, this PR could be a breaking change and therefore warrant a major version bump according to semver.