### PR TITLE
Enable use of rails model matcher in i18n-tasks.yml ast_matchers

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
@@ -4,6 +4,7 @@ require 'i18n/tasks/scanners/file_scanner'
 require 'i18n/tasks/scanners/relative_keys'
 require 'i18n/tasks/scanners/ruby_ast_call_finder'
 require 'i18n/tasks/scanners/ast_matchers/message_receivers_matcher'
+require 'i18n/tasks/scanners/ast_matchers/rails_model_matcher'
 require 'parser/current'
 
 module I18n::Tasks::Scanners


### PR DESCRIPTION
```
# i18n-tasks.yml
  ast_matchers:
    - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
```
As of now, the above does not work, because the proper file is not being included.