### PR TITLE
Fix private method called for warn deprecated

### DIFF
--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -3,6 +3,8 @@
 module I18n::Tasks
   module Translators
     class BaseTranslator
+      include ::I18n::Tasks::Logging
+      
       # @param [I18n::Tasks::BaseTask] i18n_tasks
       def initialize(i18n_tasks)
         @i18n_tasks = i18n_tasks

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -4,7 +4,6 @@ module I18n::Tasks
   module Translators
     class BaseTranslator
       include ::I18n::Tasks::Logging
-      
       # @param [I18n::Tasks::BaseTask] i18n_tasks
       def initialize(i18n_tasks)
         @i18n_tasks = i18n_tasks

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -81,7 +81,7 @@ module I18n::Tasks::Translators
       loc, sub = locale.to_s.split('-')
       if SPECIFIC_TARGETS.include?(loc)
         # Must see how the deepl api evolves, so this could be an error in the future
-        @i18n_tasks.warn_deprecated I18n.t('i18n_tasks.deepl_translate.errors.specific_target_missing') unless sub
+        # @i18n_tasks.warn_deprecated I18n.t('i18n_tasks.deepl_translate.errors.specific_target_missing') unless sub
         locale.to_s.upcase
       else
         loc.upcase

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -81,7 +81,7 @@ module I18n::Tasks::Translators
       loc, sub = locale.to_s.split('-')
       if SPECIFIC_TARGETS.include?(loc)
         # Must see how the deepl api evolves, so this could be an error in the future
-        # @i18n_tasks.warn_deprecated I18n.t('i18n_tasks.deepl_translate.errors.specific_target_missing') unless sub
+        warn_deprecated I18n.t('i18n_tasks.deepl_translate.errors.specific_target_missing') unless sub
         locale.to_s.upcase
       else
         loc.upcase

--- a/lib/i18n/tasks/translators/google_translator.rb
+++ b/lib/i18n/tasks/translators/google_translator.rb
@@ -55,7 +55,7 @@ module I18n::Tasks::Translators
         key = @i18n_tasks.translation_config[:google_translate_api_key]
         # fallback with deprecation warning
         if @i18n_tasks.translation_config[:api_key]
-          @i18n_tasks.warn_deprecated(
+          warn_deprecated(
             'Please rename Google Translate API Key from `api_key` to `google_translate_api_key`.'
           )
           key ||= translation_config[:api_key]


### PR DESCRIPTION
I have encountered a problem when trying to translate from Portuguese ("pt") to English without using the Portuguese sub locale ("pt-pt"). Which caused a `private method 'warn_deprecated' called for I18n::Tasks::BaseTask`

The use of `module_function` in `i18n/tasks/logging.rb` causes the methods to be made private and therefore makes it unable to call the `warn_deprecated` method in for example `/tasks/translators/deepl_translator.rb` and  `/tasks/translators/google_translator.rb`.

This change could potentially fix the issue in https://github.com/glebm/i18n-tasks/issues/348 as well.