### PR TITLE
Fixes typo while commenting out AstMachers in i18n-tasks.yml.

### DIFF
--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -94,7 +94,7 @@ search:
   ##     User.human_attribute_name(:email) and User.model_name.human
   ##
   ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
-  <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
+  # <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.


### PR DESCRIPTION
### What
- Commented out the unused AstMatchers in `templates/config/i18n-task.yml` that was raising the YAML error; like other places. 

### Why
- It resulted in YAML error and was stopping users from committing because of the hooks.
![Screenshot 2023-07-18 at 5 30 48 PM](https://github.com/glebm/i18n-tasks/assets/25636554/eb90f05a-110c-4831-b464-b4597684a357)


