### PR TITLE
DeepL: Default to tag_handling: xml

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -41,11 +41,11 @@ module I18n::Tasks::Translators
     end
 
     def options_for_html
-      { tag_handling: 'xml', ignore_tags: %w[i18n] }
+      { tag_handling: 'xml' }
     end
 
     def options_for_plain
-      { preserve_formatting: true, tag_handling: 'xml', ignore_tags: %w[i18n] }
+      { preserve_formatting: true, tag_handling: 'xml', html_escape: true }
     end
 
     # @param [String] value

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -41,11 +41,11 @@ module I18n::Tasks::Translators
     end
 
     def options_for_html
-      { tag_handling: 'xml' }
+      { tag_handling: 'xml', ignore_tags: %w[i18n] }
     end
 
     def options_for_plain
-      { preserve_formatting: true }
+      { preserve_formatting: true, tag_handling: 'xml', ignore_tags: %w[i18n] }
     end
 
     # @param [String] value

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -6,7 +6,7 @@ require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
   nil_value_test = ['nil-value-key', nil, nil]
-  text_test      = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Cómo estás?"]
+  text_test      = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Qué tal estás?"]
   html_test_plrl = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
   array_test     = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   fixnum_test    = ['numeric-key', 1, 1]
@@ -14,7 +14,8 @@ RSpec.describe 'DeepL Translation' do
   # this test fails atm due to moving of the bold tag =>  "Hola, <b>%{user} </b> gran O'neill ❤︎ "
   # it could be a bug, but the api also allows to ignore certain tags and there is the new html-markup version which
   # could be used too
-  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎ "]
+  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎"]
+  support_test   = ['support', '%{model} or similar', '%{model} o similar']
 
   describe 'real world test' do
     delegate :i18n_task, :in_test_app_dir, :run_cmd, to: :TestCodebase
@@ -45,7 +46,8 @@ RSpec.describe 'DeepL Translation' do
                                           'array_key' => array_test[1],
                                           'nil-value-key' => nil_value_test[1],
                                           'fixnum-key' => fixnum_test[1],
-                                          'ref-key' => ref_key_test[1]
+                                          'ref-key' => ref_key_test[1],
+                                          'support' => support_test[1]
                                         }
                                       })
           task.data[:es] = build_tree('es' => {
@@ -63,6 +65,7 @@ RSpec.describe 'DeepL Translation' do
           expect(task.t('common.ref-key', 'es')).to eq(ref_key_test[2])
           expect(task.t('common.a', 'es')).to eq('λ')
           expect(task.t('common.hello_html', 'es')).to eq(html_test[2])
+          expect(task.t('common.support', 'es')).to eq(support_test[2])
         end
       end
     end

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'DeepL Translation' do
     context 'command' do
       let(:task) { i18n_task }
 
-      it 'works' do
+      it 'works' do # rubocop:disable RSpec/MultipleExpectations
         skip 'temporarily disabled on JRuby due to https://github.com/jruby/jruby/issues/4802' if RUBY_ENGINE == 'jruby'
         skip 'DEEPL_AUTH_KEY env var not set' unless ENV['DEEPL_AUTH_KEY']
         in_test_app_dir do
@@ -47,7 +47,9 @@ RSpec.describe 'DeepL Translation' do
                                           'nil-value-key' => nil_value_test[1],
                                           'fixnum-key' => fixnum_test[1],
                                           'ref-key' => ref_key_test[1],
-                                          'support' => support_test[1]
+                                          'support' => support_test[1],
+                                          'needs_escaping' => 'Cars << Trucks / %{keep_this}',
+                                          'needs_escaping_html' => '<span>Cars</span> << Trucks / %{keep_this}'
                                         }
                                       })
           task.data[:es] = build_tree('es' => {
@@ -66,6 +68,11 @@ RSpec.describe 'DeepL Translation' do
           expect(task.t('common.a', 'es')).to eq('λ')
           expect(task.t('common.hello_html', 'es')).to eq(html_test[2])
           expect(task.t('common.support', 'es')).to eq(support_test[2])
+          expect(task.t('common.needs_escaping', 'es')).to eq('Coches << Camiones / %{keep_this}')
+          # The << is automatically escaped when calling the translation service
+          expect(
+            task.t('common.needs_escaping_html', 'es')
+          ).to eq('<span>Coches</span> &lt;&lt; Camiones / %{keep_this}')
         end
       end
     end


### PR DESCRIPTION
- Also asks DeepL to ignore the <i18n> tag which is used to wrap
  interpolated variables.
- Fixes #417
