### PR TITLE
Set the temperature of OpenAI requests to 0 to ensure consistent translation results

### DIFF
--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -85,7 +85,7 @@ module I18n::Tasks::Translators
         parameters: {
           model: 'gpt-3.5-turbo',
           messages: messages,
-          temperature: 0.7
+          temperature: 0.0
         }
       )
 


### PR DESCRIPTION
Temperatures higher than 0 make OpenAI's GPT-3.5 Turbo "hallucinate" more instead of using the most suitable next word.

Setting it to 0.7 makes the translations variable and sub-optimal.