### PR TITLE
PatternScanner: Handles non \w characters

### DIFF
--- a/lib/i18n/tasks/scanners/pattern_scanner.rb
+++ b/lib/i18n/tasks/scanners/pattern_scanner.rb
@@ -12,7 +12,7 @@ module I18n::Tasks::Scanners
     include OccurrenceFromPosition
     include RubyKeyLiterals
 
-    TRANSLATE_CALL_RE = /(?<=^|[^\w'\-.]|[^\w'-]I18n\.|I18n\.)t(?:!|ranslate!?)?/.freeze
+    TRANSLATE_CALL_RE = /(?<=^|[^\p{L}'\-.]|[^\p{L}'-]I18n\.|I18n\.)t(?:!|ranslate!?)?/.freeze
     IGNORE_LINES = {
       'coffee' => /^\s*#(?!\si18n-tasks-use)/,
       'erb' => /^\s*<%\s*#(?!\si18n-tasks-use)/,

--- a/spec/used_keys_spec.rb
+++ b/spec/used_keys_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe 'UsedKeys' do
       h1 = t 'b'
       h2 = t 'c.layer'
       h3 = t 'c.layer.underneath_c'
+      // Do not match non \w characters before the t
+      // https://github.com/glebm/i18n-tasks/issues/526
+      | À bientôt !
     SLIM
   end
 


### PR DESCRIPTION
- Fixes #526
- Switched from `\w` to `\p{L}` to match all unicode characters.
