### PR TITLE
Parse array of hashs for translators

### DIFF
--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -70,6 +70,9 @@ module I18n::Tasks
         when Array
           # dump recursively
           value.map { |v| dump_value(v, opts) }
+        when Hash
+          # dump recursively
+          value.values.map { |v| dump_value(v, opts) }
         when String
           value = CGI.escapeHTML(value) if opts[:html_escape]
           replace_interpolations value unless value.empty?
@@ -85,6 +88,9 @@ module I18n::Tasks
         when Array
           # implode array
           untranslated.map { |from| parse_value(from, each_translated, opts) }
+        when Hash
+          # implode hash
+          untranslated.transform_values { |value| parse_value(value, each_translated, opts) }
         when String
           if untranslated.empty?
             untranslated

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -5,17 +5,20 @@ require 'i18n/tasks/commands'
 require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
-  nil_value_test = ['nil-value-key', nil, nil]
-  text_test      = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Qué tal estás?"]
-  html_test_plrl = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
-  array_test     = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
-  fixnum_test    = ['numeric-key', 1, 1]
-  ref_key_test   = ['ref-key', :reference, :reference]
+  nil_value_test  = ['nil-value-key', nil, nil]
+  text_test       = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Qué tal estás?"]
+  html_test_plrl  = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
+  array_test      = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
+  array_hash_test = ['array-hash-key',
+                     [{ 'hash_key1' => 'How are you?' }, { 'hash_key2' => nil }, { 'hash_key3' => 'Well.' }],
+                     [{ 'hash_key1' => '¿Qué tal?' }, { 'hash_key2' => nil }, { 'hash_key3' => 'Bien.' }]]
+  fixnum_test     = ['numeric-key', 1, 1]
+  ref_key_test    = ['ref-key', :reference, :reference]
   # this test fails atm due to moving of the bold tag =>  "Hola, <b>%{user} </b> gran O'neill ❤︎ "
   # it could be a bug, but the api also allows to ignore certain tags and there is the new html-markup version which
   # could be used too
-  html_test      = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎"]
-  support_test   = ['support', '%{model} or similar', '%{model} o similar']
+  html_test       = ['html-key.html', "Hello, <b>%{user} big O'neill</b> ❤︎", "Hola, <b>%{user} gran O'neill</b> ❤︎"]
+  support_test    = ['support', '%{model} or similar', '%{model} o similar']
 
   describe 'real world test' do
     delegate :i18n_task, :in_test_app_dir, :run_cmd, to: :TestCodebase
@@ -44,6 +47,7 @@ RSpec.describe 'DeepL Translation' do
                                             'one' => html_test_plrl[1]
                                           },
                                           'array_key' => array_test[1],
+                                          'array_hash_key' => array_hash_test[1],
                                           'nil-value-key' => nil_value_test[1],
                                           'fixnum-key' => fixnum_test[1],
                                           'ref-key' => ref_key_test[1],


### PR DESCRIPTION
With reference to ticket #456, this change now allows you to translate lists of hashes with DeepL and other translators.