### PR TITLE
Add a configuration for OpenAI model to use

### DIFF
--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -50,6 +50,10 @@ module I18n::Tasks::Translators
       end
     end
 
+    def model
+      @model ||= @i18n_tasks.translation_config[:openai_model].presence || "gpt-3.5-turbo"
+    end
+
     def translate_values(list, from:, to:)
       results = []
 
@@ -83,7 +87,7 @@ module I18n::Tasks::Translators
 
       response = translator.chat(
         parameters: {
-          model: 'gpt-3.5-turbo',
+          model: model,
           messages: messages,
           temperature: 0.0
         }

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -113,6 +113,10 @@ search:
 #   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
 #   deepl_options:
 #     formality: prefer_less
+#   # OpenAI
+#   openai_api_key: "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+#   # openai_model: "gpt-3.5-turbo" # see https://platform.openai.com/docs/models
+
 ## Do not consider these keys missing:
 # ignore_missing:
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'


### PR DESCRIPTION
OpenAI provides [many models][0] (e.g. GPT-3.5 Turbo, GPT-4, GPT-4 Turbo, …), with different prices, context sizes, performance, …

This commit allows users to configure the model they want to use via the `translations.openai_model` entry in `i18n-tasks.yml`, but keeps the one that was previously hardcoded as default (`gpt-3.5-turbo`).

[0]: https://platform.openai.com/docs/models