### PR TITLE
Add configuration for OpenAI prompt

### DIFF
--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -51,7 +51,7 @@ module I18n::Tasks::Translators
     end
 
     def model
-      @model ||= @i18n_tasks.translation_config[:openai_model].presence || "gpt-3.5-turbo"
+      @model ||= @i18n_tasks.translation_config[:openai_model].presence || 'gpt-3.5-turbo'
     end
 
     def translate_values(list, from:, to:)

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -116,6 +116,18 @@ search:
 #   # OpenAI
 #   openai_api_key: "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 #   # openai_model: "gpt-3.5-turbo" # see https://platform.openai.com/docs/models
+#   # may contain `%{from}` and `%{to}`, which will be replaced by source and target locale codes, respectively (using `Kernel.format`)
+#   # openai_system_prompt: >-
+#   #   You are a professional translator that translates content from the %{from} locale
+#   #   to the %{to} locale in an i18n locale array.
+#   #
+#   #   The array has a structured format and contains multiple strings. Your task is to translate
+#   #   each of these strings and create a new array with the translated strings.
+#   #
+#   #   HTML markups (enclosed in < and > characters) must not be changed under any circumstance.
+#   #   Variables (starting with %%{ and ending with }) must not be changed under any circumstance.
+#   #
+#   #   Keep in mind the context of all the strings for a more accurate translation.
 
 ## Do not consider these keys missing:
 # ignore_missing:


### PR DESCRIPTION
The default prompt now includes instructions to **never** translate HTML tags (e.g. `<strong>`) nor Ruby I18n variables (e.g. `%{count}`).

This PR also makes the system prompt passed to OpenAI configurable directly from `i18n-tasks.yml`.

Incidentally, it also fixes a Rubocop offense.

This is a followup of #532.