### PR TITLE
Support DeepL glossaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,11 @@ translation:
   deepl_api_key: <DeepL Pro API key>
   deepl_host: <optional>
   deepl_version: <optional>
+  deepl_glossary_ids:
+    - f28106eb-0e06-489e-82c6-8215d6f95089
+    - 2c6415be-1852-4f54-9e1b-d800463496b4
+  deepl_options:
+    formality: prefer_less
 ```
 
 or via environment variables:

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -110,6 +110,9 @@ search:
 #   deepl_api_key: "48E92789-57A3-466A-9959-1A1A1A1A1A1A"
 #   # deepl_host: "https://api.deepl.com"
 #   # deepl_version: "v2"
+#   # deepl_glossary_ids:
+#   #   - f28106eb-0e06-489e-82c6-8215d6f95089
+#   #   - 2c6415be-1852-4f54-9e1b-d800463496b4
 #   # add additional options to the DeepL.translate call: https://www.deepl.com/docs-api/translate-text/translate-text/
 #   deepl_options:
 #     formality: prefer_less


### PR DESCRIPTION
DeepL supports creating [glossaries](https://www.deepl.com/docs-api/glossaries) via their API. Each glossary is created for a given locale pair and can then be used by passing its `id` to the `glossary_id` param of the `translate` API endpoint.

Due to this constraint, the glossary to be used can only be defined when we know the source and target locales, thus using the `glossary_id` directly in `i18n-tasks.yml` is quite unconvenient.

This commit adds a `deepl_glossary_ids` configuration entry that allows listing all glossaries that may be used for translations with DeepL as a backend.

When a DeepL translation is performed, this commit adds some logic that fetches all glossaries on DeepL (they are associated with the API key) and selects one (if any) that:
* is marked as `ready` by DeepL
* can be used for the appropriate source locale
* can be used for the appropriate target locale
* is present in the `deepl_glossary_ids` configuration