### PR TITLE
Use ast_matchers for default_i18n_subject matcher in config template

### DIFF
--- a/lib/i18n/tasks/scanners/ast_matchers/default_i18n_subject_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/default_i18n_subject_matcher.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'i18n/tasks/scanners/ast_matchers/base_matcher'
 require 'i18n/tasks/scanners/results/occurrence'
 
 module I18n::Tasks::Scanners::AstMatchers

--- a/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
@@ -3,6 +3,7 @@
 require 'i18n/tasks/scanners/file_scanner'
 require 'i18n/tasks/scanners/relative_keys'
 require 'i18n/tasks/scanners/ruby_ast_call_finder'
+require 'i18n/tasks/scanners/ast_matchers/default_i18n_subject_matcher'
 require 'i18n/tasks/scanners/ast_matchers/message_receivers_matcher'
 require 'i18n/tasks/scanners/ast_matchers/rails_model_matcher'
 require 'parser/current'

--- a/spec/used_keys_erb_spec.rb
+++ b/spec/used_keys_erb_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'i18n/tasks/scanners/ast_matchers/rails_model_matcher'
 
 RSpec.describe 'UsedKeysErb' do
   let!(:task) { I18n::Tasks::BaseTask.new }

--- a/spec/used_keys_ruby_spec.rb
+++ b/spec/used_keys_ruby_spec.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'i18n/tasks/scanners/ast_matchers/rails_model_matcher'
-require 'i18n/tasks/scanners/ast_matchers/default_i18n_subject_matcher'
 
 RSpec.describe 'UsedKeysRuby' do
   let!(:task) { I18n::Tasks::BaseTask.new }

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -96,8 +96,9 @@ search:
   ##     Matches ActionMailer's default_i18n_subject method
   ##
   ## To implement your own, please see `I18n::Tasks::Scanners::AstMatchers::BaseMatcher`.
-  # <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher') %>
-  # <%# I18n::Tasks.add_ast_matcher('I18n::Tasks::Scanners::AstMatchers::DefaultI18nSubjectMatcher') %>
+  # ast_matchers:
+  #   - 'I18n::Tasks::Scanners::AstMatchers::RailsModelMatcher'
+  #   - 'I18n::Tasks::Scanners::AstMatchers::DefaultI18nSubjectMatcher'
 
   ## Multiple scanners can be used. Their results are merged.
   ## The options specified above are passed down to each scanner. Per-scanner options can be specified as well.


### PR DESCRIPTION
Same change as #512 did for the rails_model_matcher. And update the config template as well.