### PR TITLE
Add an isolating router

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,33 @@ data:
 If you want to have i18n-tasks reorganize your existing keys using `data.write`, either set the router to
 `pattern_router` as above, or run `i18n-tasks normalize -p` (forcing the use of the pattern router for that run).
 
+##### Isolating router
+
+Isolating router assumes each YAML file is independent and can contain similar keys.
+
+As a result, the translations are written to an alternate target file for each source file
+(only the `%{locale}` part is changed to match target locale). Thus, it is not necessary to
+specify any `write` configuration (in fact, it would be completely ignored).
+
+This can be useful for example when using [ViewComponent sidecars](https://viewcomponent.org/guide/translations.html)
+(ViewComponent assigns an implicit scope to each sidecar YAML file but `i18n-tasks` is not aware of
+that logic, resulting in collisions):
+
+* `app/components/movies_component.en.yml`:
+   ```yaml
+   en:
+     title: Movies
+   ```
+
+* `app/components/games_component.en.yml`
+   ```yaml
+   en:
+     title: Games
+   ```
+
+This router has a limitation, though: it does not support detecting missing keys from code usage
+(since it is not aware of the implicit scope logic).
+
 ##### Key pattern syntax
 
 A special syntax similar to file glob patterns is used throughout i18n-tasks to match translation keys:

--- a/lib/i18n/tasks/data/router/isolating_router.rb
+++ b/lib/i18n/tasks/data/router/isolating_router.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'i18n/tasks/key_pattern_matching'
+require 'i18n/tasks/data/tree/node'
+
+module I18n::Tasks
+  module Data::Router
+    # Route based on source file path
+    class IsolatingRouter
+      include ::I18n::Tasks::KeyPatternMatching
+
+      attr_reader :config_read_patterns, :base_locale
+
+      def initialize(_adapter, data_config)
+        @base_locale = data_config[:base_locale]
+        @config_read_patterns = Array.wrap(data_config[:read])
+      end
+
+      # Route keys to destinations
+      # @param forest [I18n::Tasks::Data::Tree::Siblings] forest roots are locales.
+      # @yieldparam [String] dest_path
+      # @yieldparam [I18n::Tasks::Data::Tree::Siblings] tree_slice
+      # @return [Hash] mapping of destination => [ [key, value], ... ]
+      def route(locale, forest, &block)
+        return to_enum(:route, locale, forest) unless block
+
+        locale = locale.to_s
+        out = {}
+
+        forest.keys do |key_namespaced_with_source_path, _node|
+          source_path, key = key_namespaced_with_source_path.match(/\A<([^>]*)>\.(.*)/).captures
+          target_path = alternate_path_for(source_path, locale)
+          next unless source_path && key && target_path
+
+          (out[target_path] ||= Set.new) << "#{locale}.#{key}"
+        end
+
+        out.each do |target_path, keys|
+          file_namespace_subtree = I18n::Tasks::Data::Tree::Siblings.new(
+            nodes: forest.get("#{locale}.<#{alternate_path_for(target_path, base_locale)}>")
+          )
+          file_namespace_subtree.set_root_key!(locale)
+
+          block.yield(
+            target_path,
+            file_namespace_subtree.select_keys { |key, _| keys.include?(key) }
+          )
+        end
+      end
+
+      def alternate_path_for(source_path, locale)
+        source_path = source_path.dup
+
+        config_read_patterns.each do |pattern|
+          regexp = Glob.new(format(pattern, locale: '(*)')).to_regexp
+          next unless source_path.match?(regexp)
+
+          source_path.match(regexp) do |match_data|
+            (1..match_data.size - 1).reverse_each do |capture_index|
+              capture_begin, capture_end = match_data.offset(capture_index)
+              source_path.slice!(Range.new(capture_begin, capture_end, true))
+              source_path.insert(capture_begin, locale.to_s)
+            end
+          end
+
+          return source_path
+        end
+
+        nil
+      end
+
+      # based on https://github.com/alexch/rerun/blob/36f2d237985b670752abbe4a7f6814893cdde96f/lib/rerun/glob.rb
+      class Glob
+        NO_LEADING_DOT = '(?=[^\.])'
+        START_OF_FILENAME = '(?:\A|\/)'
+        END_OF_STRING = '\z'
+
+        def initialize(pattern)
+          @pattern = pattern
+        end
+
+        def to_regexp_string # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+          chars = smoosh(@pattern.chars)
+
+          curlies = 0
+          escaping = false
+
+          string = chars.map do |char|
+            if escaping
+              escaping = false
+              next char
+            end
+
+            case char
+            when '**' then '(?:[^/]+/)*'
+            when '*' then '.*'
+            when '?' then '.'
+            when '.' then '\.'
+            when '{'
+              curlies += 1
+              '('
+            when '}'
+              if curlies.positive?
+                curlies -= 1
+                ')'
+              else
+                char
+              end
+            when ','
+              if curlies.positive?
+                '|'
+              else
+                char
+              end
+            when '\\'
+              escaping = true
+              '\\'
+            else char
+            end
+          end.join
+
+          START_OF_FILENAME + string + END_OF_STRING
+        end
+
+        def to_regexp
+          Regexp.new(to_regexp_string)
+        end
+
+        def smoosh(chars)
+          out = []
+          until chars.empty?
+            char = chars.shift
+            if char == '*' && chars.first == '*'
+              chars.shift
+              chars.shift if chars.first == '/'
+              out.push('**')
+            else
+              out.push(char)
+            end
+          end
+          out
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/tasks/split_key.rb
+++ b/lib/i18n/tasks/split_key.rb
@@ -59,7 +59,7 @@ module I18n
         true
       end
 
-      PARENS = %w({} [] ()).each_with_object({}) do |s, h|
+      PARENS = %w({} [] () <>).each_with_object({}) do |s, h|
         i              = h.size / 2
         h[s[0].freeze] = [i, 1].freeze
         h[s[1].freeze] = [i, -1].freeze

--- a/spec/isolating_router_spec.rb
+++ b/spec/isolating_router_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Isolating router' do
+  around do |spec|
+    TestCodebase.setup(
+      'app/components/movies_component.en.yml' => { en: { title: 'Movies' } }.to_yaml,
+      'app/components/games_component.en.yml' => { en: { title: 'Games' } }.to_yaml
+    )
+    TestCodebase.in_test_app_dir { spec.run }
+    TestCodebase.teardown
+  end
+
+  let(:translated_forest) do
+    I18n::Tasks::Data::Tree::Siblings.from_nested_hash(
+      fr: {
+        '<app/components/movies_component.en.yml>': {
+          title: 'Flims'
+        },
+        '<app/components/games_component.en.yml>': {
+          title: 'Jeux'
+        }
+      }
+    )
+  end
+  let(:data) do
+    I18n::Tasks::Data::FileSystem.new(
+      router: 'isolating_router',
+      base_locale: 'en',
+      read: ['app/components/*.%{locale}.yml']
+    )
+  end
+
+  it 'namespaces each key within its file path' do
+    expect(
+      data['en']['en.<app/components/movies_component.en.yml>.title'].value
+    ).to eq 'Movies'
+
+    expect(
+      data['en']['en.<app/components/games_component.en.yml>.title'].value
+    ).to eq 'Games'
+  end
+
+  it 'routes each key to its original file alternate path' do
+    file_assignments = data.router.route(:fr, translated_forest).to_h
+
+    expect(
+      file_assignments['app/components/movies_component.fr.yml']['fr.title'].value
+    ).to eq 'Flims'
+
+    expect(
+      file_assignments['app/components/games_component.fr.yml']['fr.title'].value
+    ).to eq 'Jeux'
+  end
+
+  describe 'alternate_path_for(source_path, locale)' do
+    let(:read_config_patterns) { ['config/locales/**/*.%{locale}.yml'] }
+    let(:router) { I18n::Tasks::Data::Router::IsolatingRouter.new(nil, { read: read_config_patterns }) }
+
+    context 'when `source_path` matches a pattern of the `read` configuration' do
+      it 'changes only the `%{locale}` part of `source_path`' do
+        expect(
+          router.alternate_path_for('config/locales/somewhere/hello.en.yml', :fr)
+        ).to eq 'config/locales/somewhere/hello.fr.yml'
+      end
+
+      context 'when the `read` config has multiple `%{locale}` segments' do
+        let(:read_config_patterns) { ['config/locales/%{locale}/**/*.%{locale}.yml'] }
+
+        it 'changes all `%{locale}` parts' do
+          expect(
+            router.alternate_path_for('config/locales/en/hello.en.yml', :fr)
+          ).to eq 'config/locales/fr/hello.fr.yml'
+        end
+      end
+    end
+
+    context 'when `source_path` matches none of the read patterns' do
+      it 'returns `nil`' do
+        expect(
+          router.alternate_path_for('not_in_pattern/hello.en.yml', :fr)
+        ).to be_nil
+      end
+    end
+  end
+end

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -13,7 +13,7 @@ data:
   ## Provide a custom adapter:
   # adapter: I18n::Tasks::Data::FileSystem
 
-  # Locale files or `Find.find` patterns where translations are read from:
+  # Locale files or `Dir.glob` patterns where translations are read from:
   read:
     ## Default:
     # - config/locales/%{locale}.yml


### PR DESCRIPTION
This new router considers each source YAML file independant from each other, thus allowing each of them to include similar keys.

Here is an overview of how it works:
* when reading YAML files (as defined by patterns in the `data.read` configuration, like for other routers), it does not load them all in a common global space, but rather creates a top-level node for YAML file and then loads its content inside this node.
* when routing a given forest, it actually iterates on all top-level keys (which are source file paths) then yields the given block for each top-level key, passing also its subtree.

Note that the top-level key (which is the source file path) had to be enclosed in a character in order to prevent considering its dots (`.`) as a nesting level when de-flattening them. A mechanism to do this already existed for `{}`, `[]` and `()` but all of those enclosers have a meaning in regular expressions. Thus, this commit extends this mechanism to support `<>` and uses them as encloser for the top-level key. It also has the advantage of making this special part of the flattened key easily distinguishable by a human eye.

For example, the following YAML source files:

* `app/components/movies_component.en.yml`:

   ```yaml
   en:
     title: Movies
   ```

* `app/components/games_component.en.yml`

   ```yaml
   en:
     title: Games
   ```

… result in the following forest once loaded in memory:
```yaml
en:
  <app/components/movies_component.en.yml>:
    title: Movies
  <app/components/games_component.en.yml>:
    title: Games
```

… which in turn results in the following flattened keys:
```
en.<app/components/movies_component.en.yml>.title: Movies
en.<app/components/games_component.en.yml>.title: Games
```

… which can be sent to any translator and should come back as:
```
fr.<app/components/movies_component.en.yml>.title: Flims
fr.<app/components/games_component.en.yml>.title: Jeux
```

… finally, this router allows re-assigning each key to the appropriate target file, which gives:

* `app/components/movies_component.fr.yml`:

   ```yaml
   fr:
     title: Flims
   ```

* `app/components/games_component.fr.yml`

   ```yaml
   fr:
     title: Jeux
   ```

This implicitely adds support for ViewComponent (which suggests organizing YAML files in "sidecars" and which adds an implicit scope to keys in those files, based on their file path).