### PR TITLE
Install gem into development group only?

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ i18n-tasks can be used with any project using the ruby [i18n gem][i18n-gem] (def
 Add i18n-tasks to the Gemfile:
 
 ```ruby
-gem 'i18n-tasks', '~> 1.0.13'
+gem 'i18n-tasks', '~> 1.0.13', group: :development
 ```
 
 Copy the default [configuration file](#configuration):


### PR DESCRIPTION
While investigating memory usage with derailed I realized that I could save a small chunk of memory in production by moving the il8n-tasks gem to the development group.

<img width="1271" alt="Screenshot 2023-12-28 at 09 23 48" src="https://github.com/glebm/i18n-tasks/assets/395132/61f0a2df-2eea-4693-9b56-8fa59228fe6c">

Should this gem be installed in the development group only?

This PR is just an update to the README Gemfile install line.