### PR TITLE
Fix key splitting failures if key contains any parenthesis char

### DIFF
--- a/spec/split_key_spec.rb
+++ b/spec/split_key_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe 'SplitKey' do
     ['a.#{b.c}', %w[a #{b.c}]],
     ['a.#{b.c}.', %w[a #{b.c}]],
     ['a.#{b.c}.d', %w[a #{b.c} d]],
-    ['a.#{b.c}.d.[e.f]', %w(a #{b.c} d [e.f])]
+    ['a.#{b.c}.d.[e.f]', %w(a #{b.c} d [e.f])],
+    ['a.#{b.c}.d.<e.f>', %w[a #{b.c} d <e.f>]],
+    ['a.b->c.d.<e.f>', %w[a b->c d <e.f>]],
+    ['a.b.c.d.<e.f', %w[a b c d <e f]] # Opened but never closed
     # rubocop:enable Lint/InterpolationCheck
   ].each do |(arg, ret)|
     it "#{arg} is split into #{ret.inspect}" do


### PR DESCRIPTION
Note that the complete split_key function has been refactored to be more readable, and a test has been added to check for the failures that occurred previously

Closes #549