### PR TITLE
Fix unescaped interpolated reserved key in help text and handle escaped interpolations in inconsistent interpolations check

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,12 +16,10 @@ en:
           data_format: 'Data format: %{valid_text}.'
           keep_order: Keep the order of the keys
           key_pattern: Filter by key pattern (e.g. 'common.*')
-          key_pattern_to_rename: Full key (pattern) to rename. Required
           locale: :i18n_tasks.common.locale
           locale_to_translate_from: Locale to translate from
           locales_filter: 'Locale(s) to process. Special: base'
           missing_types: 'Filter by types: %{valid}'
-          new_key_name: New name, interpolates original name as %{key}. Required
           nostdin: Do not read from stdin
           out_format: 'Output format: %{valid_text}'
           pattern_router: 'Use pattern router: keys moved per config data.write'
@@ -30,8 +28,8 @@ en:
             the config setting if set.
           translation_backend: Translation backend (google or deepl)
           value: >-
-            Value. Interpolates: %{value}, %{human_key}, %{key}, %{default}, %{value_or_human_key},
-            %{value_or_default_or_human_key}
+            Value. Interpolates: %%{value}, %%{human_key}, %%{key}, %%{default}, %%{value_or_human_key},
+            %%{value_or_default_or_human_key}
       desc:
         add_missing: add missing keys to locale data, optionally match a pattern
         check_consistent_interpolations: verify that all translations use correct interpolation variables

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -13,22 +13,20 @@ ru:
           data_format: 'Формат данных: %{valid_text}.'
           keep_order: Keep the order of the keys
           key_pattern: Маска ключа (например, common.*)
-          key_pattern_to_rename: Полный ключ (шаблон) для переименования. Необходимый параметр.
           locale: 'Язык. По умолчанию: base'
           locale_to_translate_from: 'Язык, с которого переводить (по умолчанию: base)'
           locales_filter: >-
             Список языков для обработки, разделенный запятыми (,). По умолчанию: все. Специальное
             значение: base.
           missing_types: 'Типы недостающих переводов: %{valid}. По умолчанию: все'
-          new_key_name: Новое имя, интерполирует оригинальное название как %{key}. Необходимый параметр.
           nostdin: Не читать дерево из стандартного ввода
           out_format: 'Формат вывода: %{valid_text}.'
           pattern_router: 'Использовать pattern_router: ключи распределятся по файлам согласно data.write'
           strict: Не угадывать динамические использования ключей, например `t("category.#{category.key}")`
           translation_backend: Движок перевода (google или deepl)
           value: >-
-            Значение, интерполируется с %{value}, %{human_key}, %{key}, %{default}, %{value_or_human_key},
-            %{value_or_default_or_human_key}
+            Значение, интерполируется с %%{value}, %%{human_key}, %%{key}, %%{default}, %%{value_or_human_key},
+            %%{value_or_default_or_human_key}
       desc:
         add_missing: добавить недостающие ключи к переводам
         check_consistent_interpolations: убедитесь, что во всех переводах используются правильные

--- a/lib/i18n/tasks/command/options/common.rb
+++ b/lib/i18n/tasks/command/options/common.rb
@@ -26,7 +26,7 @@ module I18n::Tasks
         arg :value,
             '-v',
             '--value VALUE',
-            t('i18n_tasks.cmd.args.desc.value')
+            t('i18n_tasks.cmd.args.desc.value', dummy: 'value') # Dummy value is workaround for https://github.com/ruby-i18n/i18n/issues/689
 
         arg :config,
             '-c',

--- a/lib/i18n/tasks/interpolations.rb
+++ b/lib/i18n/tasks/interpolations.rb
@@ -5,7 +5,7 @@ module I18n::Tasks
     class << self
       attr_accessor :variable_regex
     end
-    @variable_regex = /%{[^}]+}/.freeze
+    @variable_regex = /(?<!%)%{[^}]+}/.freeze
 
     def inconsistent_interpolations(locales: nil, base_locale: nil) # rubocop:disable Metrics/AbcSize
       locales ||= self.locales


### PR DESCRIPTION
This fixes #552 if and only if https://github.com/ruby-i18n/i18n/pull/688 or an equivalent is merged for the i18n gem. Otherwise escaping the offending interpolations does not appease the reserved keyword check.

This PR also contains a workaround for another related to escaped interpolations (https://github.com/ruby-i18n/i18n/issues/689), see the code comment.

I removed some unused translations that had interpolations in them, their usage was removed in c1d1312.