### PR TITLE
Stop modifying locale before sending to Google Translate

### DIFF
--- a/lib/i18n/tasks/translators/google_translator.rb
+++ b/lib/i18n/tasks/translators/google_translator.rb
@@ -22,8 +22,8 @@ module I18n::Tasks::Translators
     def options_for_translate_values(from:, to:, **options)
       options.merge(
         api_key: api_key,
-        from: to_google_translate_compatible_locale(from),
-        to: to_google_translate_compatible_locale(to)
+        from: from,
+        to: to,
       )
     end
 
@@ -40,15 +40,6 @@ module I18n::Tasks::Translators
     end
 
     private
-
-    SUPPORTED_LOCALES_WITH_REGION = %w[zh-CN zh-TW].freeze
-
-    # Convert 'es-ES' to 'es'
-    def to_google_translate_compatible_locale(locale)
-      return locale unless locale.include?('-') && !SUPPORTED_LOCALES_WITH_REGION.include?(locale)
-
-      locale.split('-', 2).first
-    end
 
     def api_key
       @api_key ||= begin


### PR DESCRIPTION
In https://github.com/glebm/i18n-tasks/pull/292 the from/to locales were modified to be limited to just the language portion of a locale tag except if it was within one of the listed set of `langague-REGION` tags. This was to fix https://github.com/glebm/i18n-tasks/issues/286.

That change no longer seems to be required by the underlying API:

```ruby
EasyTranslate.translate("horse", to: "es")       # => "caballo"
EasyTranslate.translate("horse", to: "es-es")    # => "caballo"
EasyTranslate.translate("horse", to: "es-ES")    # => "caballo"

EasyTranslate.translate("caballo", to: "en")     # => "horse"
EasyTranslate.translate("caballo", to: "en-us")  # => "horse"
EasyTranslate.translate("caballo", to: "en-US")  # => "horse"
```

And maintaining that list directly in code causes several small issues, #555 #556, and #557 which actually is translating things into the incorrect language altogether.

Given that, it seems worthy of removing the vestigial locale modification code entirely and just relying on new improved behavior of the Google Translate API and EasyTranslate.