### PR TITLE
Add support for AWS Translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ $ i18n-tasks translate-missing --backend=openai
 $ i18n-tasks translate-missing --from=en es fr
 ```
 
+### AWS Translate missing keys
+
+Translate missing values with AWS ([more below on configuration](#aws-translation-config)).
+
+```console
+$ i18n-tasks translate-missing --backend=aws
+
+# accepts from and locales options:
+$ i18n-tasks translate-missing --from=en es fr
+```
+
 ### Find usages
 
 See where the keys are used with `i18n-tasks find`:
@@ -504,6 +515,26 @@ or via environment variable:
 ```bash
 OPENAI_API_KEY=<OpenAI API key>
 OPENAI_MODEL=<optional>
+```
+<a name="aws-translation-config"></a>
+### AWS Translate
+
+`i18n-tasks translate-missing` requires AWS Credentials with access to AWS::Translate::TranslateText. 
+
+```yaml
+# config/i18n-tasks.yml
+translation:
+  aws_region: <AWS Region>
+  aws_access_key_id: <AWS Access Key ID>
+  aws_secret_access_key: <AWS Secret Access Key>
+```
+
+or via environment variable:
+
+```bash
+AWS_REGION=<AWS Region>
+AWS_ACCESS_KEY_ID=<AWS Access Key ID>
+AWS_SECRET_ACCESS_KEY=<AWS Secret Access Key>
 ```
 
 ## Interactive console

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,12 @@ en:
           Set OpenAI API key via OPENAI_API_KEY environment variable or translation.openai_api_key
           in config/i18n-tasks.yml. Get the key at https://openai.com/.
         no_results: OpenAI returned no results.
+    aws_translate:
+      errors:
+        no_api_key: >-
+          Set up valid credentails with access to AWS Translate via AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY environment variables
+          or translation.aws_region, translation.aws_access_key_id, aws_secret_access_key in config/i18n-tasks.yml.
+        no_results: AWS returned no results.
     remove_unused:
       confirm:
         one: "%{count} translation will be removed from %{locales}."

--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -60,4 +60,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'deepl-rb', '>= 2.1.0'
   s.add_development_dependency 'easy_translate', '>= 0.5.1' # Google Translate
   s.add_development_dependency 'yandex-translator', '>= 0.3.3'
+  s.add_development_dependency 'aws-sdk-translate', '>= 1.63.0' # aws translate
 end

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -69,6 +69,9 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
       conf[:openai_api_key] = ENV['OPENAI_API_KEY'] if ENV.key?('OPENAI_API_KEY')
       conf[:openai_model] = ENV['OPENAI_MODEL'] if ENV.key?('OPENAI_MODEL')
       conf[:yandex_api_key] = ENV['YANDEX_API_KEY'] if ENV.key?('YANDEX_API_KEY')
+      conf[:aws_region] = ENV['AWS_REGION'] if ENV.key?('AWS_REGION')
+      conf[:aws_access_key_id] = ENV['AWS_ACCESS_KEY_ID'] if ENV.key?('AWS_ACCESS_KEY_ID')
+      conf[:aws_secret_access_key] = ENV['AWS_SECRET_ACCESS_KEY'] if ENV.key?('AWS_SECRET_ACCESS_KEY')
       conf
     end
   end

--- a/lib/i18n/tasks/translation.rb
+++ b/lib/i18n/tasks/translation.rb
@@ -4,6 +4,7 @@ require 'i18n/tasks/translators/deepl_translator'
 require 'i18n/tasks/translators/google_translator'
 require 'i18n/tasks/translators/openai_translator'
 require 'i18n/tasks/translators/yandex_translator'
+require 'i18n/tasks/translators/aws_translator'
 
 module I18n::Tasks
   module Translation
@@ -21,6 +22,8 @@ module I18n::Tasks
         Translators::OpenAiTranslator.new(self).translate_forest(forest, from)
       when :yandex
         Translators::YandexTranslator.new(self).translate_forest(forest, from)
+      when :aws
+        Translators::AwsTranslator.new(self).translate_forest(forest, from)
       else
         fail CommandError, "invalid backend: #{backend}"
       end

--- a/lib/i18n/tasks/translators/aws_translator.rb
+++ b/lib/i18n/tasks/translators/aws_translator.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'i18n/tasks/translators/base_translator'
+
+module I18n::Tasks::Translators
+  class AwsTranslator < BaseTranslator
+    def initialize(*)
+      begin
+        require 'aws-sdk-translate'
+      rescue LoadError
+        raise ::I18n::Tasks::CommandError, "Add gem 'aws-sdk-translate' to your Gemfile to use this command"
+      end
+      super
+    end
+
+    protected
+
+    def translate_values(list, **options)
+      list.map do |str| 
+        aws_translate_client.translate_text(
+          options.merge( text: str )
+        ).translated_text
+      end
+    end
+
+    def options_for_translate_values(from:, to:, **options)
+      options.merge(
+        source_language_code: from,
+        target_language_code: to,
+      )
+    end
+
+    def options_for_html
+      {}
+    end
+
+    def options_for_plain
+      {}
+    end
+
+    def no_results_error_message
+      I18n.t('i18n_tasks.aws_translate.errors.no_results')
+    end
+
+    private
+
+    def aws_translate_client
+      @aws_translate_client ||= Aws::Translate::Client.new(region: region, credentials: credentials)
+    end
+
+    def region
+      @region ||= @i18n_tasks.translation_config[:aws_region]
+    end
+
+    def credentials
+      @credentials ||= begin
+                         aws_access_key_id = @i18n_tasks.translation_config[:aws_access_key_id]
+                         aws_secret_access_key = @i18n_tasks.translation_config[:aws_secret_access_key]
+                         fail ::I18n::Tasks::CommandError, I18n.t('i18n_tasks.aws_translate.errors.no_api_key') if aws_access_key_id.blank? || aws_secret_access_key.blank?
+                         Aws::Credentials.new(aws_access_key_id, aws_secret_access_key)
+                       end
+    end
+  end
+end

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -135,6 +135,10 @@ search:
 #   #   Variables (starting with %%{ and ending with }) must not be changed under any circumstance.
 #   #
 #   #   Keep in mind the context of all the strings for a more accurate translation.
+#   # AWS
+#   # aws_region: "us-east-1"
+#   # aws_access_key_id: "XXXXXXXX"
+#   # aws_secret_access_key: "XXXXXXXX"
 
 ## Do not consider these keys missing:
 # ignore_missing:


### PR DESCRIPTION
# Purpose
Allow use of AWS Translate API to fetch translations

# Approach
Add new aws_translator that fulfills the methods required by BaseTranslator
Add new config options for required credentials for instantiating an Aws::Translate::Client
* region
* aws_access_key_id
* aws_secret_access_key
