### PR TITLE
Google Translator: Handles line breaks

### DIFF
--- a/spec/google_translate_spec.rb
+++ b/spec/google_translate_spec.rb
@@ -4,14 +4,16 @@ require 'spec_helper'
 require 'i18n/tasks/commands'
 
 RSpec.describe 'Google Translation' do
-  nil_value_test = ['nil-value-key', nil, nil]
-  empty_value_test = ['empty-value-key', '', '']
-  text_test      = ['key', "Hello, %{user} O'Neill!", "¡Hola, %{user} O'Neill!"]
-  html_test      = ['html-key.html', "Hello, <b>%{user} O'neill</b>", "Hola, <b>%{user} O'neill</b>"]
-  html_test_plrl = ['html-key.html.one', '<b>Hello %{count}</b>', '<b>Hola %{count}</b>']
-  array_test     = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
-  fixnum_test    = ['numeric-key', 1, 1]
-  ref_key_test   = ['ref-key', :reference, :reference]
+  nil_value_test      = ['nil-value-key', nil, nil]
+  empty_value_test    = ['empty-value-key', '', '']
+  text_test           = ['hello', "Hello, %{user} O'Neill!", "¡Hola, %{user} O'Neill!"]
+  text_test_multiline = ['hello_multiline', "Hello,\n%{user}\nO'Neill!", "Hola,\n%{user}\n¡O'Neill!"]
+  html_test           = ['html-key.html', "Hello, <b>%{user} O'neill</b>", "Hola, <b>%{user} O'neill</b>"]
+  html_test_plrl      = ['html-key.html.one', '<b>Hello %{count}</b>', '<b>Hola %{count}</b>']
+  html_test_multiline = ['html-key.html.multiline', "<b>Hello</b>\n<b>%{user}</b>", "<b>Hola</b>\n<b>%{user}</b>"]
+  array_test          = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
+  fixnum_test          = ['numeric-key', 1, 1]
+  ref_key_test        = ['ref-key', :reference, :reference]
 
   describe 'real world test' do
     delegate :i18n_task, :in_test_app_dir, :run_cmd, to: :TestCodebase
@@ -36,10 +38,12 @@ RSpec.describe 'Google Translation' do
                                         'common' => {
                                           'a' => 'λ',
                                           'hello' => text_test[1],
+                                          'hello_multiline' => text_test_multiline[1],
                                           'hello_html' => html_test[1],
                                           'hello_plural_html' => {
                                             'one' => html_test_plrl[1]
                                           },
+                                          'hello_multiline_html' => html_test_multiline[1],
                                           'array_key' => array_test[1],
                                           'nil-value-key' => nil_value_test[1],
                                           'empty-value-key' => empty_value_test[1],
@@ -55,8 +59,10 @@ RSpec.describe 'Google Translation' do
 
           run_cmd 'translate-missing'
           expect(task.t('common.hello', 'es')).to eq(text_test[2])
+          expect(task.t('common.hello_multiline', 'es')).to eq(text_test_multiline[2])
           expect(task.t('common.hello_html', 'es')).to eq(html_test[2])
           expect(task.t('common.hello_plural_html.one', 'es')).to eq(html_test_plrl[2])
+          expect(task.t('common.hello_multiline_html', 'es')).to eq(html_test_multiline[2])
           expect(task.t('common.array_key', 'es')).to eq(array_test[2])
           expect(task.t('common.nil-value-key', 'es')).to eq(nil_value_test[2])
           expect(task.t('common.empty-value-key', 'es')).to eq(empty_value_test[2])


### PR DESCRIPTION
- Line breaks are not kept when translating html content via Google Translate
- Therefore we transform `\n` into a placeholder and then back after
  translating
- Fixes #566
