### PR TITLE
Add missing changes to changelog for 1.0.14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,18 @@
   [#550](https://github.com/glebm/i18n-tasks/pull/550)
 * Non-HTML ERB files are now supported.
   [#545](https://github.com/glebm/i18n-tasks/pull/545)
-* Improved interpolations handling for DeepL.
-  [#523](https://github.com/glebm/i18n-tasks/pull/523)
+* Adds an optional isolating router that assumes each YAML file is independent.
+  [#541](https://github.com/glebm/i18n-tasks/pull/541)
+* Adds an optional AST matcher for Rails default_i18n_subject.
+  [#538](https://github.com/glebm/i18n-tasks/pull/538) [#539](https://github.com/glebm/i18n-tasks/pull/539)
+* Supports DeepL glossaries.
+  [#535](https://github.com/glebm/i18n-tasks/pull/535)
+* Supports hashes for DeepL and other translators.
+  [#531](https://github.com/glebm/i18n-tasks/pull/531)
+* Adds configuration for OpenAI prompt.
+  [#533](https://github.com/glebm/i18n-tasks/pull/533)
+* Adds configuration for OpenAI model.
+  [#532](https://github.com/glebm/i18n-tasks/pull/532) [#534](https://github.com/glebm/i18n-tasks/pull/534)
 
 ## v1.0.13
 

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -34,7 +34,7 @@ data:
     ## Example (replace %#= with %=):
     # - "<%#= %x[bundle info vagrant --path].chomp %>/templates/locales/%{locale}.yml"
 
-  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, or a custom class.
+  ## Specify the router (see Readme for details). Valid values: conservative_router, pattern_router, isolating_router, or a custom class.
   # router: conservative_router
 
   yaml:


### PR DESCRIPTION
Thank you for the 1.0.14 release!

There are a few changes missing from the changelog. I added them based on https://github.com/glebm/i18n-tasks/compare/v1.0.13...v1.0.14. There are two potentially relevant changes that I skipped, 2bd951f and e939d0e.

The improved interpolation handling with DeepL was released with 1.0.13 and its changelog already lists it, so I removed it from the 1.0.14 changes.