### PR TITLE
Uses AST-scanner for all ERB

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,88 +1,88 @@
 ## Unreleased
 
-- Uses AST-parser for all ERB-files, not just `.html.erb`
-- [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
+* Uses AST-parser for all ERB-files, not just `.html.erb`
+* [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
 
 ## v1.0.14
 
-- Newlines are now preserved when using Google Translate.
+* Newlines are now preserved when using Google Translate.
   [#567](https://github.com/glebm/i18n-tasks/pull/567)
-- Improved locale name handling for Google Translate.
+* Improved locale name handling for Google Translate.
   [#558](https://github.com/glebm/i18n-tasks/pull/558)
-- Fixes compatibility with some versions of the i18n gem.
+* Fixes compatibility with some versions of the i18n gem.
   [#553](https://github.com/glebm/i18n-tasks/pull/553)
-- Added `i18n-tasks cp` command.
+* Added `i18n-tasks cp` command.
   [#551](https://github.com/glebm/i18n-tasks/pull/551)
-- Parentheses in keys are now supported.
+* Parentheses in keys are now supported.
   [#550](https://github.com/glebm/i18n-tasks/pull/550)
-- Non-HTML ERB files are now supported.
+* Non-HTML ERB files are now supported.
   [#545](https://github.com/glebm/i18n-tasks/pull/545)
-- Adds an optional isolating router that assumes each YAML file is independent.
+* Adds an optional isolating router that assumes each YAML file is independent.
   [#541](https://github.com/glebm/i18n-tasks/pull/541)
-- Adds an optional AST matcher for Rails default_i18n_subject.
+* Adds an optional AST matcher for Rails default_i18n_subject.
   [#538](https://github.com/glebm/i18n-tasks/pull/538) [#539](https://github.com/glebm/i18n-tasks/pull/539)
-- Supports DeepL glossaries.
+* Supports DeepL glossaries.
   [#535](https://github.com/glebm/i18n-tasks/pull/535)
-- Supports hashes for DeepL and other translators.
+* Supports hashes for DeepL and other translators.
   [#531](https://github.com/glebm/i18n-tasks/pull/531)
-- Adds configuration for OpenAI prompt.
+* Adds configuration for OpenAI prompt.
   [#533](https://github.com/glebm/i18n-tasks/pull/533)
-- Adds configuration for OpenAI model.
+* Adds configuration for OpenAI model.
   [#532](https://github.com/glebm/i18n-tasks/pull/532) [#534](https://github.com/glebm/i18n-tasks/pull/534)
 
 ## v1.0.13
 
-- OpenAI translator.
+* OpenAI translator.
   [#519](https://github.com/glebm/i18n-tasks/pull/519)
-- DeepL
-  - More robust interpolation handling.
+* DeepL
+  * More robust interpolation handling.
     [#523](https://github.com/glebm/i18n-tasks/pull/523)
-  - Configurable formality level.
+  * Configurable formality level.
     [#477](https://github.com/glebm/i18n-tasks/pull/477)
-  - Send requests in batches.
+  * Send requests in batches.
     [#474](https://github.com/glebm/i18n-tasks/pull/474)
-- Support partially dynamic segments in non-strict mode (e.g. `t "cats.#{cat}-bio.name"`).
+* Support partially dynamic segments in non-strict mode (e.g. `t "cats.#{cat}-bio.name"`).
   [#509](https://github.com/glebm/i18n-tasks/pull/509)
-- Fixes `grep_keys` in Ruby 3+.
+* Fixes `grep_keys` in Ruby 3+.
   [#492](https://github.com/glebm/i18n-tasks/pull/492)
-- Improved handling of older libyaml versions.
+* Improved handling of older libyaml versions.
   [#493](https://github.com/glebm/i18n-tasks/pull/493)
 
 ## v1.0.12
 
-- The heuristic for detecting non-plural keys that look like plural keys has been removed
+* The heuristic for detecting non-plural keys that look like plural keys has been removed
   because it was causing other issues. Please use `ignore_missing` to handle such keys.
   [#461](https://github.com/glebm/i18n-tasks/issues/461)
-- Adds support for plural default values,
+* Adds support for plural default values,
   e.g. `t('test', default: { one: '1', other: '2' })`.
   [#464](https://github.com/glebm/i18n-tasks/issues/464)
-- Adds the `-p` pattern option to the `missing`, `add-missing`, and `translate-missing` commands.
+* Adds the `-p` pattern option to the `missing`, `add-missing`, and `translate-missing` commands.
   [#469](https://github.com/glebm/i18n-tasks/issues/469)
-- Relaxes version restriction for the `better_html` depedency to allow v2.x.
+* Relaxes version restriction for the `better_html` depedency to allow v2.x.
   [#471](https://github.com/glebm/i18n-tasks/pull/471)
-- Support filenames where locale is separated by a `-`, e.g. `user-en.yml` instead of the usual `user.en.yml`.
+* Support filenames where locale is separated by a `-`, e.g. `user-en.yml` instead of the usual `user.en.yml`.
   [#467](https://github.com/glebm/i18n-tasks/pull/467)
 
 ## v1.0.11
 
-- Fixes `--config` command line flag.
+* Fixes `--config` command line flag.
   [#455](https://github.com/glebm/i18n-tasks/pull/455)
 
-- Fixes circular `require` warnings on Ruby 3.1.2.
+* Fixes circular `require` warnings on Ruby 3.1.2.
   [#457](https://github.com/glebm/i18n-tasks/pull/457)
 
-- `*.xlsx` files are now excluded by default.
+* `*.xlsx` files are now excluded by default.
   [#458](https://github.com/glebm/i18n-tasks/pull/458)
 
 ## v1.0.10
 
-- Fixes `relative_exclude_method_name_paths`.
+* Fixes `relative_exclude_method_name_paths`.
   Previously, the code used `exclude_method_name_paths` instead of `relative_exclude_method_name_paths`.
   [#454](https://github.com/glebm/i18n-tasks/pull/454)
 
 ## v1.0.9
 
-- Adds an optional AST matcher for Rails model translations, such as `human_attribute_name`.
+* Adds an optional AST matcher for Rails model translations, such as `human_attribute_name`.
 
   Can be enabled by adding the following to the config:
 
@@ -94,164 +94,164 @@
 
 ## v1.0.8
 
-- Fixes a crash in `strict: false` mode.
+* Fixes a crash in `strict: false` mode.
   [#445](https://github.com/glebm/i18n-tasks/pull/445)
 
 ## v1.0.7
 
-- Fixes an issue with `scope:` argument parsing.
+* Fixes an issue with `scope:` argument parsing.
   [#442](https://github.com/glebm/i18n-tasks/pull/442)
 
 ## v1.0.6
 
-- Fixes handling of more types of ERB comments.
+* Fixes handling of more types of ERB comments.
   [#437](https://github.com/glebm/i18n-tasks/pull/437)
 
 ## v1.0.5
 
-- Fixes handling of multiline ERB comments.
+* Fixes handling of multiline ERB comments.
   [#431](https://github.com/glebm/i18n-tasks/issues/431)
 
 ## v1.0.4
 
-- Fixes handling of ERB comments without a space between `%` and `#` (`<%# ... %>`).
+* Fixes handling of ERB comments without a space between `%` and `#` (`<%# ... %>`).
   [#429](https://github.com/glebm/i18n-tasks/pull/429)
-- Better support for the `it` gem.
+* Better support for the `it` gem.
   [#361](https://github.com/glebm/i18n-tasks/issues/361)
 
 ## v1.0.3
 
-- Fixes inline block handling in ERB files.
+* Fixes inline block handling in ERB files.
   [#427](https://github.com/glebm/i18n-tasks/pull/427)
 
 ## v1.0.2
 
-- Fixes block call handling in ERB files.
+* Fixes block call handling in ERB files.
   [#425](https://github.com/glebm/i18n-tasks/pull/425)
 
 ## v1.0.1
 
-- Fixes `better_html` scanning the project.
+* Fixes `better_html` scanning the project.
   [#422](https://github.com/glebm/i18n-tasks/issues/422)
 
 ## v1.0.0
 
-- Log [#StandWithUkraine](https://stand-with-ukraine.pp.ua/) to stderr on every CLI command.
-- Improved ERB parsing: Replaces a regexp-based parser with an AST parser.
+* Log [#StandWithUkraine](https://stand-with-ukraine.pp.ua/) to stderr on every CLI command.
+* Improved ERB parsing: Replaces a regexp-based parser with an AST parser.
   [#416](https://github.com/glebm/i18n-tasks/pull/416)
-- Fixes compatibility with Psych 4.0+ and Ruby 3.1.
+* Fixes compatibility with Psych 4.0+ and Ruby 3.1.
   [#415](https://github.com/glebm/i18n-tasks/pull/415)
-- Works around an emoji handling bug in libyaml.
+* Works around an emoji handling bug in libyaml.
   [#421](https://github.com/glebm/i18n-tasks/pull/421)
 
 ## v0.9.37
 
-- Reverted `"#{hash["key"]}"` pattern scanner support because it caused a number of issues.
+* Reverted `"#{hash["key"]}"` pattern scanner support because it caused a number of issues.
   [#410](https://github.com/glebm/i18n-tasks/pull/410)
-- Drops support for Ruby < 2.6.
+* Drops support for Ruby < 2.6.
   [#2552cdb3](https://github.com/glebm/i18n-tasks/commit/2552cdb36a94a801e64d6b71279353dbbedb1618)
 
 ## v0.9.36
 
-- Fixes ActiveSupport 7 compatibility.
+* Fixes ActiveSupport 7 compatibility.
   [#403](https://github.com/glebm/i18n-tasks/pull/403)
-- Fixes mixed optional and keyword arguments in `I18n::Tasks::BaseTask.new`.
+* Fixes mixed optional and keyword arguments in `I18n::Tasks::BaseTask.new`.
   [#401](https://github.com/glebm/i18n-tasks/issues/401)
-- `*.map` files are now ignored by default.
+* `*.map` files are now ignored by default.
   [#399](https://github.com/glebm/i18n-tasks/pull/399)
-- `data` task now supports the `key-values` format that outputs a TSV.
+* `data` task now supports the `key-values` format that outputs a TSV.
   [#398](https://github.com/glebm/i18n-tasks/pull/398)
-- `"#{hash["key"]}"` interpolations are now supported in the pattern scanner.
+* `"#{hash["key"]}"` interpolations are now supported in the pattern scanner.
   [#397](https://github.com/glebm/i18n-tasks/pull/397) [#405](https://github.com/glebm/i18n-tasks/pull/405)
-- Forward slash (`/`) is now an allowed character in translation keys.
+* Forward slash (`/`) is now an allowed character in translation keys.
   [#396](https://github.com/glebm/i18n-tasks/pull/396)
 
 ## v0.9.35
 
-- New CLI argument `--config`, to specify the config file location.
+* New CLI argument `--config`, to specify the config file location.
   [#394](https://github.com/glebm/i18n-tasks/issues/394)
-- Allow relative keys in any Ruby object.
+* Allow relative keys in any Ruby object.
   [#381](https://github.com/glebm/i18n-tasks/issues/381)
-- Fix not ignoring missing for pluralization.
+* Fix not ignoring missing for pluralization.
   [#389](https://github.com/glebm/i18n-tasks/issues/389)
-- A more robust translation interpolation replacement token.
+* A more robust translation interpolation replacement token.
   [#392](https://github.com/glebm/i18n-tasks/pull/392)
-- Add `deepl_host` and `deepl_version` to translation config.
+* Add `deepl_host` and `deepl_version` to translation config.
   [#384](https://github.com/glebm/i18n-tasks/pull/384)
-- Add `*.jpeg` to the default ignore list.
+* Add `*.jpeg` to the default ignore list.
   [#382](https://github.com/glebm/i18n-tasks/pull/382)
 
 ## v0.9.34
 
-- Fixes Ruby 3.0 compatibility.
+* Fixes Ruby 3.0 compatibility.
   [#370](https://github.com/glebm/i18n-tasks/issues/370)
-- Drops support for Ruby < 2.5.
+* Drops support for Ruby < 2.5.
   [#e71a3bf](https://github.com/glebm/i18n-tasks/commit/e71a3bf37e46606aaaea1df81108f8e43aa4a5a1)
 
 ## v0.9.33
 
-- Fixes DeepL translation.
+* Fixes DeepL translation.
   [#367](https://github.com/glebm/i18n-tasks/pull/367)
 
 ## v0.9.32
 
-- Support capitalized region names in locale codes (e.g. "zh-YUE")
+* Support capitalized region names in locale codes (e.g. "zh-YUE")
   [#357](https://github.com/glebm/i18n-tasks/pull/357)
-- DeepL: Fix single value translation.
+* DeepL: Fix single value translation.
   [#d31297b5](https://github.com/glebm/i18n-tasks/commit/d31297b557687b022e4534927237e4dfd1fdfd23)
-- Fix missing key detection for external keys in non-base locale.
+* Fix missing key detection for external keys in non-base locale.
   [#364](https://github.com/glebm/i18n-tasks/issues/364)
-- `required_ruby_version`: Allow Ruby 3.x.
-- Fix deprecation warnings on Ruby 2.7.1.
+* `required_ruby_version`: Allow Ruby 3.x.
+* Fix deprecation warnings on Ruby 2.7.1.
   [#352](https://github.com/glebm/i18n-tasks/pull/352)
 
 ## v0.9.31
 
-- Add Yandex translator backend.
+* Add Yandex translator backend.
   [#343](https://github.com/glebm/i18n-tasks/pull/343)
-- Fix more Ruby 2.7 warnings.
+* Fix more Ruby 2.7 warnings.
   [#344](https://github.com/glebm/i18n-tasks/pull/344)
 
 ## v0.9.30
 
-- Fix keyword arguments warnings in Ruby 2.7.
+* Fix keyword arguments warnings in Ruby 2.7.
   [#342](https://github.com/glebm/i18n-tasks/pull/342)
-- Recognize `t!` and `translate!` methods.
+* Recognize `t!` and `translate!` methods.
   [#329](https://github.com/glebm/i18n-tasks/issues/329)
-- Test template now tests for inconsistent interpolations.
+* Test template now tests for inconsistent interpolations.
   [#317](https://github.com/glebm/i18n-tasks/pull/317)
 
 ## v0.9.29
 
-- The `remove_unused` command now supports `--pattern`.
+* The `remove_unused` command now supports `--pattern`.
   [#327](https://github.com/glebm/i18n-tasks/pull/327)
-- Common audio and video file extensions are now ignored.
+* Common audio and video file extensions are now ignored.
   [#324](https://github.com/glebm/i18n-tasks/issues/324)
-- The test templates for RSpec and minitest now include consistent interpolations check.
+* The test templates for RSpec and minitest now include consistent interpolations check.
   [#317](https://github.com/glebm/i18n-tasks/pull/317)
-- Leaf->tree expansion warnings are no longer issued for plural keys (where they are legal).
+* Leaf->tree expansion warnings are no longer issued for plural keys (where they are legal).
   [#314](https://github.com/glebm/i18n-tasks/pull/314)
-- Single line comments are now ignored in `.js` and `.es6` files.
+* Single line comments are now ignored in `.js` and `.es6` files.
   Magic comments are still supported (e.g. `// i18n-tasks-use I18n.t('hello')`).
   [#322](https://github.com/glebm/i18n-tasks/issues/322)
-- No longer loads all of `rails-i18n` and doesn't set `I18n.enforce_available_locales`,
+* No longer loads all of `rails-i18n` and doesn't set `I18n.enforce_available_locales`,
   fixing some compatibility issues introduced in v0.9.28.
   [#315](https://github.com/glebm/i18n-tasks/issues/315)
 
 ## v0.9.28
 
-- The `missing` command now also detects incomplete pluralizations.
+* The `missing` command now also detects incomplete pluralizations.
   [#308](https://github.com/glebm/i18n-tasks/issues/308)
 
 ## v0.9.27
 
-- Fixes `check-consistent-interpolations` when the same interpolation is used more than once.
+* Fixes `check-consistent-interpolations` when the same interpolation is used more than once.
 
 ## v0.9.26
 
-- `eq-base` command now returns a non-zero exit code if there are any results.
+* `eq-base` command now returns a non-zero exit code if there are any results.
   [#301](https://github.com/glebm/i18n-tasks/pull/301)
-- New command, `check-consistent-interpolations`, checks that %-interpolations across all locales are consistent.
+* New command, `check-consistent-interpolations`, checks that %-interpolations across all locales are consistent.
   The corresponding ignore setting is `ignore_inconsistent_interpolations`.
 
   This check also runs as part of the `health` command.
@@ -260,23 +260,23 @@
 
 ## v0.9.25
 
-- Adds an optional `--keep-order` (`-k`) parameter to `remove-unused`.
+* Adds an optional `--keep-order` (`-k`) parameter to `remove-unused`.
   When passed, keys in the files are not sorted after removing the unused keys.
   [#297](https://github.com/glebm/i18n-tasks/pull/297)
-- Drops support for Ruby < 2.3.
+* Drops support for Ruby < 2.3.
   [#298](https://github.com/glebm/i18n-tasks/pull/298)
-- Fixes a rare concurrency issue, most easily reproduced on Rubinius.
+* Fixes a rare concurrency issue, most easily reproduced on Rubinius.
   [#300](https://github.com/glebm/i18n-tasks/issues/300)
-- Avoid Google / DeepL translating empty keys (a minor optimization).
+* Avoid Google / DeepL translating empty keys (a minor optimization).
   [#fc529e78](https://github.com/glebm/i18n-tasks/commit/fc529e78d2421ad08e7a93c0164e5d0be1492e40)
 
 ## v0.9.24
 
-- Makes `deepl-rb` and `easy_translate` dependencies optional.
+* Makes `deepl-rb` and `easy_translate` dependencies optional.
   [#296](https://github.com/glebm/i18n-tasks/issues/296)
-- Adds DeepL support to `tree-translate`.
-- Removes the deprecated `tree-rename-key` command.
-- Removes obsolete XSLX report functionality.
+* Adds DeepL support to `tree-translate`.
+* Removes the deprecated `tree-rename-key` command.
+* Removes obsolete XSLX report functionality.
 
 ## v0.9.23
 
@@ -375,10 +375,10 @@ I18n::Tasks.add_scanner(
 
 ## v0.9.14
 
-- AST scanner: support nested `t` calls in ruby files.
+* AST scanner: support nested `t` calls in ruby files.
   [#c61f4e00](https://github.com/glebm/i18n-tasks/commit/c61f4e00ee67d7e9963ddb44ed3228f551cc1cad)
 
-- Exclude `*.swf` and `*.flv` files by default.
+* Exclude `*.swf` and `*.flv` files by default.
   [#233](https://github.com/glebm/i18n-tasks/issues/233)
 
 ## v0.9.13
@@ -392,25 +392,25 @@ and [fixing](https://github.com/glebm/i18n-tasks/pull/235) the issue!
 
 This is a minor bugfix release.
 
-- Do not warn about "adding children to leaf" for keys found in source.
+* Do not warn about "adding children to leaf" for keys found in source.
   [#228](https://github.com/glebm/i18n-tasks/pull/228)
-- Fix an issue with nested keys with the `scope` argument in views.
+* Fix an issue with nested keys with the `scope` argument in views.
   [#224](https://github.com/glebm/i18n-tasks/issues/224)
 
 ## v0.9.11
 
 This is a minor bugfix release.
 
-- Fixes another issue with the `scope` argument in views.
+* Fixes another issue with the `scope` argument in views.
   [#224](https://github.com/glebm/i18n-tasks/issues/224)
 
 ## v0.9.10
 
 This is a minor bugfix release.
 
-- Fixes parenthesized `t()` calls with a `scope` argument in views.
+* Fixes parenthesized `t()` calls with a `scope` argument in views.
   [#224](https://github.com/glebm/i18n-tasks/issues/224)
-- Fixes the `i18n-tasks irb` task.
+* Fixes the `i18n-tasks irb` task.
   [#222](https://github.com/glebm/i18n-tasks/issues/222)
 
 ## v0.9.9
@@ -436,404 +436,404 @@ This release adds the `mv` command for renaming/moving the keys.
 
 This is a minor bugfix release.
 
-- Fixed `add-missing` command ignoring the locales argument.
+* Fixed `add-missing` command ignoring the locales argument.
   [#205](https://github.com/glebm/i18n-tasks/issues/205)
-- Always require `PatternMapper` so that it doesn't need requiring in the config.
+* Always require `PatternMapper` so that it doesn't need requiring in the config.
   [#204](https://github.com/glebm/i18n-tasks/issues/204)
-- If `internal_locale` is set to a locale that's not available, reset it to `en` and print a warning.
+* If `internal_locale` is set to a locale that's not available, reset it to `en` and print a warning.
   [#202](https://github.com/glebm/i18n-tasks/issues/202)
 
 ## 0.9.6
 
 This is a minor bugfix release.
 
-- Fixes the `ignore_lines` PatternScanner feature. [#206](https://github.com/glebm/i18n-tasks/issues/206)
-- Allows `:` to be a part of the key. [#207](https://github.com/glebm/i18n-tasks/issues/207)
-- Fixes translation of plural HTML keys. [#193](https://github.com/glebm/i18n-tasks/issues/193)
+* Fixes the `ignore_lines` PatternScanner feature. [#206](https://github.com/glebm/i18n-tasks/issues/206)
+* Allows `:` to be a part of the key. [#207](https://github.com/glebm/i18n-tasks/issues/207)
+* Fixes translation of plural HTML keys. [#193](https://github.com/glebm/i18n-tasks/issues/193)
 
 ## 0.9.5
 
-- Add a `PatternMapper` scanner for mapping bits of code to keys [#191](https://github.com/glebm/i18n-tasks/issues/191).
-- Add missing keys with `nil` value by passing `--nil-value` to `add-missing`. [#170](https://github.com/glebm/i18n-tasks/issues/170)
-- Requiring `i18n-tasks` no longer overrides `I18n.locale`. [#190](https://github.com/glebm/i18n-tasks/issues/190).
+* Add a `PatternMapper` scanner for mapping bits of code to keys [#191](https://github.com/glebm/i18n-tasks/issues/191).
+* Add missing keys with `nil` value by passing `--nil-value` to `add-missing`. [#170](https://github.com/glebm/i18n-tasks/issues/170)
+* Requiring `i18n-tasks` no longer overrides `I18n.locale`. [#190](https://github.com/glebm/i18n-tasks/issues/190).
 
 ## 0.9.4
 
-- Improve reporting for reference keys throughout.
+* Improve reporting for reference keys throughout.
 
 ## 0.9.3
 
-- Support i18n `:symbol` reference keys. [#150](https://github.com/glebm/i18n-tasks/issues/150)
-- Fixes dynamic key matching issue with nested `#{}`. [#180](https://github.com/glebm/i18n-tasks/issues/180)
+* Support i18n `:symbol` reference keys. [#150](https://github.com/glebm/i18n-tasks/issues/150)
+* Fixes dynamic key matching issue with nested `#{}`. [#180](https://github.com/glebm/i18n-tasks/issues/180)
 
 ## 0.9.2
 
-- Fix ActiveSupport >= 4.0 but < 4.2 compatibility. [#178](https://github.com/glebm/i18n-tasks/issues/178)
-- Locale file path rewriting now matches locales as directories and multiple instances of the locale in the path. [#176](https://github.com/glebm/i18n-tasks/issues/176) [#177](https://github.com/glebm/i18n-tasks/issues/177)
+* Fix ActiveSupport >= 4.0 but < 4.2 compatibility. [#178](https://github.com/glebm/i18n-tasks/issues/178)
+* Locale file path rewriting now matches locales as directories and multiple instances of the locale in the path. [#176](https://github.com/glebm/i18n-tasks/issues/176) [#177](https://github.com/glebm/i18n-tasks/issues/177)
 
 ## 0.9.1
 
-- New method: `I18n::Tasks.add_scanner(scanner_class_name, scanner_opts)` to add a scanner to the default configuration.
-- New method: `I18n::Tasks.add_commands(commands_module)` to add commands to `i18n-tasks`.
-- Only match `I18n` or `nil` receivers in PatternScanner.
+* New method: `I18n::Tasks.add_scanner(scanner_class_name, scanner_opts)` to add a scanner to the default configuration.
+* New method: `I18n::Tasks.add_commands(commands_module)` to add commands to `i18n-tasks`.
+* Only match `I18n` or `nil` receivers in PatternScanner.
 
 ## 0.9.0
 
-- Support for multiple scanners.
-- AST scanner for `.rb` files.
-- `default:` argument support for `add-missing -v`. AST scanner only. [#55](https://github.com/glebm/i18n-tasks/issues/55)
-- Recognize that only `t` calls can use relative keys, not `I18n.t`. AST scanner only. [#106](https://github.com/glebm/i18n-tasks/issues/106)
-- Strict mode enabled by default, can be configured via `search.strict`. New argument: `--no-strict`.
-- `search.include` renamed to `search.only`.
+* Support for multiple scanners.
+* AST scanner for `.rb` files.
+* `default:` argument support for `add-missing -v`. AST scanner only.  [#55](https://github.com/glebm/i18n-tasks/issues/55)
+* Recognize that only `t` calls can use relative keys, not `I18n.t`. AST scanner only. [#106](https://github.com/glebm/i18n-tasks/issues/106)
+* Strict mode enabled by default, can be configured via `search.strict`. New argument: `--no-strict`.
+* `search.include` renamed to `search.only`.
 
 ## 0.8.7
 
-- New interpolation value for `add-missing -v`: `%{key}`. [Stijn Mathysen](https://github.com/stijnster) [#164](https://github.com/glebm/i18n-tasks/pull/164)
-- When adding keys from non-default locales, merge base locale first, then the others. [#162](https://github.com/glebm/i18n-tasks/issues/162)
+* New interpolation value for `add-missing -v`: `%{key}`. [Stijn Mathysen](https://github.com/stijnster) [#164](https://github.com/glebm/i18n-tasks/pull/164)
+* When adding keys from non-default locales, merge base locale first, then the others. [#162](https://github.com/glebm/i18n-tasks/issues/162)
 
 ## 0.8.6
 
-- Report missing keys found in source in all the locales. [#162](https://github.com/glebm/i18n-tasks/issues/162)
-- Fix `data-remove` task. [#140](https://github.com/glebm/i18n-tasks/issues/140)
-- Non-zero exit code on `health`, `missing`, and `unused` if such keys are present. [#151](https://github.com/glebm/i18n-tasks/issues/151)
-- XLSX report compatibility with the OSX Numbers App. [#159](https://github.com/glebm/i18n-tasks/issues/159)
-- RSpec template compatibility with `config.expose_dsl_globally = false`. [#148](https://github.com/glebm/i18n-tasks/issues/148)
-- `bundle show vagrant` example in the config template is no longer interpolated .[#161](https://github.com/glebm/i18n-tasks/issues/161)
+* Report missing keys found in source in all the locales. [#162](https://github.com/glebm/i18n-tasks/issues/162)
+* Fix `data-remove` task. [#140](https://github.com/glebm/i18n-tasks/issues/140)
+* Non-zero exit code on `health`, `missing`, and `unused` if such keys are present. [#151](https://github.com/glebm/i18n-tasks/issues/151)
+* XLSX report compatibility with the OSX Numbers App. [#159](https://github.com/glebm/i18n-tasks/issues/159)
+* RSpec template compatibility with `config.expose_dsl_globally = false`. [#148](https://github.com/glebm/i18n-tasks/issues/148)
+* `bundle show vagrant` example in the config template is no longer interpolated .[#161](https://github.com/glebm/i18n-tasks/issues/161)
 
 ## 0.8.5
 
-- Fix regression: Plugin support [#153](https://github.com/glebm/i18n-tasks/issues/153).
+* Fix regression: Plugin support [#153](https://github.com/glebm/i18n-tasks/issues/153).
 
 ## 0.8.4
 
-- Support relative keys in mailers [#155](https://github.com/glebm/i18n-tasks/issues/155).
+* Support relative keys in mailers [#155](https://github.com/glebm/i18n-tasks/issues/155).
 
 ## 0.8.3
 
-- Fix regression: ActiveSupport < 4 support [#143](https://github.com/glebm/i18n-tasks/issues/143).
+* Fix regression: ActiveSupport < 4 support [#143](https://github.com/glebm/i18n-tasks/issues/143).
 
 ## 0.8.2
 
-- Fix failure on nil values in the data config [#142](https://github.com/glebm/i18n-tasks/issues/142).
+* Fix failure on nil values in the data config [#142](https://github.com/glebm/i18n-tasks/issues/142).
 
 ## 0.8.1
 
-- The default config file now excludes `app/assets/images` and `app/assets/fonts`. Add `*.otf` to ignored extensions.
-- If an error message occurs when scanning, the error message now includes the filename [#141](https://github.com/glebm/i18n-tasks/issues/141).
+* The default config file now excludes `app/assets/images` and `app/assets/fonts`. Add `*.otf` to ignored extensions.
+* If an error message occurs when scanning, the error message now includes the filename [#141](https://github.com/glebm/i18n-tasks/issues/141).
 
 ## 0.8.0
 
-- Parse command line arguments with `optparse`. Remove dependency on Slop.
+* Parse command line arguments with `optparse`. Remove dependency on Slop.
   Simplified commands DSL: options are mostly passed directly to optparse.
-- `search.relative_roots` default changed from from `%w(app/views)` to
+* `search.relative_roots` default changed from from `%w(app/views)` to
   `%w(app/views app/controllers app/helpers app/presenters)`.
-- `add-missing` now adds keys detected in source to all locales (previously just base) [#134](https://github.com/glebm/i18n-tasks/issues/134).
-- The default spec template no long requires `spec_helper` by default [Daniel Levenson](https://github.com/dleve123) [#135](https://github.com/glebm/i18n-tasks/pull/135).
-- `search.exclude` now appends to and not overrides the default exclude list. More extensions excluded by default:
-  _.css, _.sass, _.scss, _.less, _.yml, and _.json. [#137](https://github.com/glebm/i18n-tasks/issues/137).
+* `add-missing` now adds keys detected in source to all locales (previously just base) [#134](https://github.com/glebm/i18n-tasks/issues/134).
+* The default spec template no long requires `spec_helper` by default [Daniel Levenson](https://github.com/dleve123) [#135](https://github.com/glebm/i18n-tasks/pull/135).
+* `search.exclude` now appends to and not overrides the default exclude list. More extensions excluded by default:
+  *.css, *.sass, *.scss, *.less, *.yml, and *.json. [#137](https://github.com/glebm/i18n-tasks/issues/137).
 
 ## 0.7.13
 
-- Fix relative keys when controller name consists of more than one word by [Yuji Nakayama](https://github.com/yujinakayama) [#132](https://github.com/glebm/i18n-tasks/pull/132).
-- Support keys with UTF8 word characters in the name. [#133](https://github.com/glebm/i18n-tasks/issues/133).
-- Change missing report column title from "Details" to "Value in other locales or source", display the locale [#130](https://github.com/glebm/i18n-tasks/issues/130).
+* Fix relative keys when controller name consists of more than one word by [Yuji Nakayama](https://github.com/yujinakayama) [#132](https://github.com/glebm/i18n-tasks/pull/132).
+* Support keys with UTF8 word characters in the name. [#133](https://github.com/glebm/i18n-tasks/issues/133).
+* Change missing report column title from "Details" to "Value in other locales or source", display the locale [#130](https://github.com/glebm/i18n-tasks/issues/130).
 
 ## 0.7.12
 
-- Handle relative keys in controllers nested in modules by [Alexander Tipugin](https://github.com/atipugin). [#128](https://github.com/glebm/i18n-tasks/issues/128).
-- Only write files that changed [#125](https://github.com/glebm/i18n-tasks/issues/125).
-- Allow `[]` in the non-strict scanner pattern [#127](https://github.com/glebm/i18n-tasks/issues/127).
+* Handle relative keys in controllers nested in modules by [Alexander Tipugin](https://github.com/atipugin). [#128](https://github.com/glebm/i18n-tasks/issues/128).
+* Only write files that changed [#125](https://github.com/glebm/i18n-tasks/issues/125).
+* Allow `[]` in the non-strict scanner pattern [#127](https://github.com/glebm/i18n-tasks/issues/127).
 
 ## 0.7.11
 
-- Set slop dependency to 3.5 to ensure Ruby 1.9 compatibility ([#121](https://github.com/glebm/i18n-tasks/pull/121)).
+* Set slop dependency to 3.5 to ensure Ruby 1.9 compatibility ([#121](https://github.com/glebm/i18n-tasks/pull/121)).
   MRI 1.9 EOL is [February 23, 2015](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/).
   We will support 1.9 until rbx and jruby support 2.0.
 
 ## 0.7.10
 
-- Support relative keys in controller action with argument
+* Support relative keys in controller action with argument
 
 ## 0.7.9
 
-- Support relative keys in Rails controller actions by [Jessie A. Young](https://github.com/jessieay). [#46](https://github.com/glebm/i18n-tasks/issues/46).
-- Minor fixes
+* Support relative keys in Rails controller actions by [Jessie A. Young](https://github.com/jessieay). [#46](https://github.com/glebm/i18n-tasks/issues/46).
+* Minor fixes
 
 ## 0.7.8
 
-- Fix Google Translate issues with non-string keys [#100](https://github.com/glebm/i18n-tasks/pull/100)
-- Fix an issue with certain HAML not being parsed [#96](https://github.com/glebm/i18n-tasks/issues/96) [#102](https://github.com/glebm/i18n-tasks/pull/102)
-- Fix other minor issues
+* Fix Google Translate issues with non-string keys [#100](https://github.com/glebm/i18n-tasks/pull/100)
+* Fix an issue with certain HAML not being parsed [#96](https://github.com/glebm/i18n-tasks/issues/96) [#102](https://github.com/glebm/i18n-tasks/pull/102)
+* Fix other minor issues
 
 ## 0.7.7
 
-- Fix regression: keys are sorted once again [#92](https://github.com/glebm/i18n-tasks/issues/92).
+* Fix regression: keys are sorted once again [#92](https://github.com/glebm/i18n-tasks/issues/92).
 
 ## 0.7.6
 
-- Add a post-install notice with setup commands
-- Fix a small typo in the config template [#91](https://github.com/glebm/i18n-tasks/pull/91).
-- Fix `find` crashing on relative keys (regression)
+* Add a post-install notice with setup commands
+* Fix a small typo in the config template [#91](https://github.com/glebm/i18n-tasks/pull/91).
+* Fix `find` crashing on relative keys (regression)
 
 ## 0.7.5
 
 Dynamic key usage inference fixes by [Mikko Koski](https://github.com/rap1ds):
 
-- Append `:` to keys ending with dot '.' (to scan `t('category.' + cat)` as `t('category.:')`)
-- Consider keys ending with `:` as match expressions
-- Make `@` a valid character for keys (to allow `t("category.#{@cat}"`)
+* Append `:` to keys ending with dot '.' (to scan `t('category.' + cat)` as `t('category.:')`)
+* Consider keys ending with `:` as match expressions
+* Make `@` a valid character for keys (to allow `t("category.#{@cat}"`)
 
 ## 0.7.4
 
-- Fix `add-missing --help`
-- Fix a minor issue with `health` [#88](https://github.com/glebm/i18n-tasks/issues/88)
+* Fix `add-missing --help`
+* Fix a minor issue with `health` [#88](https://github.com/glebm/i18n-tasks/issues/88)
 
 ## 0.7.3
 
-- New task `translate-tree`
-- Bugs fixed: [nil values and Google Translate](https://github.com/glebm/i18n-tasks/issues/85), [config file encoding issue](#82).
+* New task `translate-tree`
+* Bugs fixed: [nil values and Google Translate](https://github.com/glebm/i18n-tasks/issues/85), [config file encoding issue](#82).
 
 ## 0.7.2
 
-- i18n-tasks now analyses itself! `internal_locale` setting has been added, that controls i18n-tasks reporting language.
-  English and Russian are available in this release.
+* i18n-tasks now analyses itself! `internal_locale` setting has been added, that controls i18n-tasks reporting language.
+English and Russian are available in this release.
 
 ## 0.7.1
 
-- 1.9.3 compatibility
+* 1.9.3 compatibility
 
 ## 0.7.0
 
 New tasks:
 
-- `i18n-tasks health` to display missing and unused keys along with other information
-- `i18n-tasks tree-` to manipulate trees
-- `i18n-tasks data-` to look up and manipulate locale data
-- Better `help` for all commands
-- Minor bug fixes
+* `i18n-tasks health` to display missing and unused keys along with other information
+* `i18n-tasks tree-` to manipulate trees
+* `i18n-tasks data-` to look up and manipulate locale data
+* Better `help` for all commands
+* Minor bug fixes
 
 Internally:
 
-- Refactored commands DSL
-- `add-missing`, `remove-unused` implemented in terms of the new `tree-` commands
+* Refactored commands DSL
+* `add-missing`, `remove-unused` implemented in terms of the new `tree-` commands
 
 ## 0.6.3
 
-- Strict mode added for `unused` and `remove-unused`. When passed `-s` or `--strict`, these tasks will not attempt to infer dynamic key usages, such as `t("category.#{category.key}")`.
-- Arrays are now supported as values for Google Translate [#77](https://github.com/glebm/i18n-tasks/issues/77)
+* Strict mode added for `unused` and `remove-unused`. When passed `-s` or `--strict`, these tasks will not attempt to infer dynamic key usages, such as `t("category.#{category.key}")`.
+* Arrays are now supported as values for Google Translate [#77](https://github.com/glebm/i18n-tasks/issues/77)
 
 ## 0.6.2
 
-- New task to show locale data: `i18n-tasks data`
-- New output format: `keys`, e.g. `i18n-tasks data -fkeys`
-- Fix an issue with a top-level dynamic key breaking unused detection [#75](https://github.com/glebm/i18n-tasks/issues/75)
-- Document [magic comment hints](https://github.com/glebm/i18n-tasks#fine-tuning)
+* New task to show locale data: `i18n-tasks data`
+* New output format: `keys`, e.g. `i18n-tasks data -fkeys`
+* Fix an issue with a top-level dynamic key breaking unused detection [#75](https://github.com/glebm/i18n-tasks/issues/75)
+* Document [magic comment hints](https://github.com/glebm/i18n-tasks#fine-tuning)
 
 ## 0.6.1
 
-- Fix Google Translate issue with plural keys and missing billing info error
+* Fix Google Translate issue with plural keys and missing billing info error
 
 ## 0.6.0
 
-- New output format options for reports: yaml, json, and inspect.
-- Templates for config and rspec.
-- Keys with values same as base locale have been moved from `missing` into a separate task, `eq-base`.
-- `missing` now also shows keys that are present in some locale but not in base locale.
-- Terminal output: no more Type column in `missing`, first code usage shown for keys missing base value.
-- `relative_roots` configuration key moved to `search.relative_roots`, deprecation warning (removed in the next minor).
+* New output format options for reports: yaml, json, and inspect.
+* Templates for config and rspec.
+* Keys with values same as base locale have been moved from `missing` into a separate task, `eq-base`.
+* `missing` now also shows keys that are present in some locale but not in base locale.
+* Terminal output: no more Type column in `missing`, first code usage shown for keys missing base value.
+* `relative_roots` configuration key moved to `search.relative_roots`, deprecation warning (removed in the next minor).
 
 ## 0.5.4
 
-- ActiveSupport 3 compatibility
+* ActiveSupport 3 compatibility
 
 ## 0.5.3
 
-- Fix Google translate regression
-- More robust config output
+* Fix Google translate regression
+* More robust config output
 
 ## 0.5.2
 
-- Ignore lines during search with `config.search.ignore_lines`. Ignores comments by default.
-- Fixed minor issues with `i18-tasks config` output.
+* Ignore lines during search with `config.search.ignore_lines`. Ignores comments by default.
+* Fixed minor issues with `i18-tasks config` output.
 
 ## 0.5.1
 
-- Fix [conservative router](https://github.com/glebm/i18n-tasks#conservative-router).
-- Conservative router is now the default.
+* Fix [conservative router](https://github.com/glebm/i18n-tasks#conservative-router).
+* Conservative router is now the default.
 
 ## 0.5.0
 
-- internals refactored to use trees everywhere
-- type `guide` in `i18n-tasks irb` to learn more about the commands
-- (remove-)unused tasks now work per locale
-- `ignore` settings are shown on `i18n-tasks config`
-- Rubinius 2.2.7 compatibility
+* internals refactored to use trees everywhere
+* type `guide` in `i18n-tasks irb` to learn more about the commands
+* (remove-)unused tasks now work per locale
+* `ignore` settings are shown on `i18n-tasks config`
+* Rubinius 2.2.7 compatibility
 
 ## 0.4.5
 
-- Respect tty color setting
+* Respect tty color setting
 
 ## 0.4.4
 
-- Fix google translate issues with plural keys and translating from non-base locale
+* Fix google translate issues with plural keys and translating from non-base locale
 
 ## 0.4.3
 
-- Ruby 1.9 compatibility
+* Ruby 1.9 compatibility
 
 ## 0.4.2
 
-- Ruby 1.9.3-compatible again
+* Ruby 1.9.3-compatible again
 
 ## 0.4.1
 
-- Improved error messages across the board
-- Fixed google translate issue with \_html keys [#67](https://github.com/glebm/i18n-tasks/issues/67).
+* Improved error messages across the board
+* Fixed google translate issue with _html keys [#67](https://github.com/glebm/i18n-tasks/issues/67).
 
 ## 0.4.0
 
-- In addition to pattern router, a new conservative router that keeps the keys in place. (See [#57](https://github.com/glebm/i18n-tasks/issues/57))
-- `i18n-tasks irb` for debugging
-- This release is a major refactoring to use real trees internally (as opposed to nested hashes).
-  Real trees allow for much easier [traversal](/lib/i18n/tasks/data/tree/traversal.rb).
-  With these trees, information can be associated with each node, which allows for things like the conservative router.
-- Accept keys with dashes (`-`) [#64](https://github.com/glebm/i18n-tasks/issues/64).
+* In addition to pattern router, a new conservative router that keeps the keys in place. (See [#57](https://github.com/glebm/i18n-tasks/issues/57))
+* `i18n-tasks irb` for debugging
+* This release is a major refactoring to use real trees internally (as opposed to nested hashes).
+Real trees allow for much easier [traversal](/lib/i18n/tasks/data/tree/traversal.rb).
+With these trees, information can be associated with each node, which allows for things like the conservative router.
+* Accept keys with dashes (`-`) [#64](https://github.com/glebm/i18n-tasks/issues/64).
 
 ## 0.3.11
 
-- Improve plural key handling
+* Improve plural key handling
 
 ## 0.3.10
 
-- New (de)serialization options in config
-- `add-missing` placeholder argument can now use %{base_value}.
+* New (de)serialization options in config
+* `add-missing` placeholder argument can now use %{base_value}.
 
 ## 0.3.9
 
-- Fix regression: Remove ActiveSupport::HashWithIndifferentAccess from locale data output
+* Fix regression: Remove ActiveSupport::HashWithIndifferentAccess from locale data output
 
 ## 0.3.8
 
-- Fix activesupport ~3.x compatibility issue (#45).
+* Fix activesupport ~3.x compatibility issue (#45).
 
 ## 0.3.7
 
-- Catch Errno::EPIPE to allow `i18n-tasks <command> | head` for large reports
-- Improved i18n-tasks config output
+* Catch Errno::EPIPE to allow `i18n-tasks <command> | head` for large reports
+* Improved i18n-tasks config output
 
 ## v0.3.6
 
-- fix issue with Google Translate
+* fix issue with Google Translate
 
 ## v0.3.5
 
-- `config.locales` is now picked up by default from paths do data files. `base_locale` defaults to `en`.
+* `config.locales` is now picked up by default from paths do data files. `base_locale` defaults to `en`.
 
 ## v0.3.3..v0.3.4
 
-- Bugfixes
+* Bugfixes
 
 ## v0.3.2
 
-- Tasks that accept locales now accept them as the first argument(s)
+* Tasks that accept locales now accept them as the first argument(s)
 
 ## v0.3.0
 
-- i18n-tasks is a binary now (instead of rake tasks). All tasks / commands now accept various options, and there is no need for as many of them as before.
-- Works faster on Rails as it doesn't load anything but the gem, but now requires `base_locale` and `locales` to be set in config.
+* i18n-tasks is a binary now (instead of rake tasks). All tasks / commands now accept various options, and there is no need for as many of them as before.
+* Works faster on Rails as it doesn't load anything but the gem, but now requires `base_locale` and `locales` to be set in config.
 
 ## v0.2.21..v0.2.22
 
-- `rake i18n:usages[pattern]`
-- performance regression fixes
+* `rake i18n:usages[pattern]`
+* performance regression fixes
 
 ## v0.2.20
 
-- `rake i18n:usages` report
+* `rake i18n:usages` report
 
 ## v0.2.17..v0.2.19
 
-- Bugfixes
+* Bugfixes
 
 ## v0.2.16
 
-- Key search extracted into its own class, and a custom scanner can now be provided.
-- Removed support for deprecated settings
+* Key search extracted into its own class, and a custom scanner can now be provided.
+* Removed support for deprecated settings
 
 ## v0.2.15
 
-- More robust I18n.t call detection (detect I18n.translate and multiline calls)
+* More robust I18n.t call detection (detect I18n.translate and multiline calls)
 
 ## v0.2.14
 
-- Google Translate fixes: preserve interpolations, set correct format based on the key (text or html).
+* Google Translate fixes: preserve interpolations, set correct format based on the key (text or html).
 
 ## v0.2.13
 
-- New setting relative_roots for relative key resolution (default: %w(app/views))
-- fix google translation attempts to translate non-string keys
+* New setting relative_roots for relative key resolution (default: %w(app/views))
+* fix google translation attempts to translate non-string keys
 
 ## v0.2.11 .. v0.2.12
 
-- New task: `i18n:remove_unused`
+* New task: `i18n:remove_unused`
 
 ## v0.2.5..0.2.10
 
-- config/i18n-tasks.yml now processed with ERB
-- can now be used with any ruby apps, not just Rails
-- more locale formats are considered valid
-- `i18n:missing` accepts locales
-- `i18n:missing` supports plural keys
+* config/i18n-tasks.yml now processed with ERB
+* can now be used with any ruby apps, not just Rails
+* more locale formats are considered valid
+* `i18n:missing` accepts locales
+* `i18n:missing` supports plural keys
 
 ## v0.2.4
 
-- more powerful key pattern matching with sets and backtracking
+* more powerful key pattern matching with sets and backtracking
 
 ## v0.2.3
 
-- spreadsheet report, tests run on rbx
+* spreadsheet report, tests run on rbx
 
 ## v0.2.2
 
-- improved output with terminal-table
+* improved output with terminal-table
 
 ## v0.2.1
 
-- fill tasks renamed, fix symbol key search
+* fill tasks renamed, fix symbol key search
 
 ## v0.2.0
 
-- 3 more prefill tasks, including Google Translate
-- tasks renamed
+* 3 more prefill tasks, including Google Translate
+* tasks renamed
 
 ## v0.1.8
 
-- improved search: no longer uses grep, more robust detection (@natano)
+* improved search: no longer uses grep, more robust detection (@natano)
 
 ## v0.1.7
 
-- ability to route prefill output via data.write config
-- multiple configuration variables renamed (still understands old syntax with deprecation warnings)
+* ability to route prefill output via data.write config
+* multiple configuration variables renamed (still understands old syntax with deprecation warnings)
 
 ## v0.1.6
 
-- New key pattern syntax for i18n-tasks.yml a la globbing
+* New key pattern syntax for i18n-tasks.yml a la globbing
 
 ## v0.1.5
 
-- Removed get_locale_data, added data configuration options
+* Removed get_locale_data, added data configuration options
 
 ## v0.1.4
 
-- Fix relative keys in partials (@paulfioravanti)
-- Fix i18n:missing when nothing is missing (@tamtamchik)
+* Fix relative keys in partials (@paulfioravanti)
+* Fix i18n:missing when nothing is missing (@tamtamchik)
 
 ## v0.1.3
 
-- detect countable keys as used for unused task
-- account for non-string keys coming from yaml (thanks @lichtamberg)
+* detect countable keys as used for unused task
+* account for non-string keys coming from yaml (thanks @lichtamberg)
 
 ## v0.1.2
 
-- added grep config options (thanks @dmke)
-- improved terminal output
+* added grep config options (thanks @dmke)
+* improved terminal output

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,83 +1,88 @@
+## Unreleased
+
+- Uses AST-parser for all ERB-files, not just `.html.erb`
+- [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
+
 ## v1.0.14
 
-* Newlines are now preserved when using Google Translate.
+- Newlines are now preserved when using Google Translate.
   [#567](https://github.com/glebm/i18n-tasks/pull/567)
-* Improved locale name handling for Google Translate.
+- Improved locale name handling for Google Translate.
   [#558](https://github.com/glebm/i18n-tasks/pull/558)
-* Fixes compatibility with some versions of the i18n gem.
+- Fixes compatibility with some versions of the i18n gem.
   [#553](https://github.com/glebm/i18n-tasks/pull/553)
-* Added `i18n-tasks cp` command.
+- Added `i18n-tasks cp` command.
   [#551](https://github.com/glebm/i18n-tasks/pull/551)
-* Parentheses in keys are now supported.
+- Parentheses in keys are now supported.
   [#550](https://github.com/glebm/i18n-tasks/pull/550)
-* Non-HTML ERB files are now supported.
+- Non-HTML ERB files are now supported.
   [#545](https://github.com/glebm/i18n-tasks/pull/545)
-* Adds an optional isolating router that assumes each YAML file is independent.
+- Adds an optional isolating router that assumes each YAML file is independent.
   [#541](https://github.com/glebm/i18n-tasks/pull/541)
-* Adds an optional AST matcher for Rails default_i18n_subject.
+- Adds an optional AST matcher for Rails default_i18n_subject.
   [#538](https://github.com/glebm/i18n-tasks/pull/538) [#539](https://github.com/glebm/i18n-tasks/pull/539)
-* Supports DeepL glossaries.
+- Supports DeepL glossaries.
   [#535](https://github.com/glebm/i18n-tasks/pull/535)
-* Supports hashes for DeepL and other translators.
+- Supports hashes for DeepL and other translators.
   [#531](https://github.com/glebm/i18n-tasks/pull/531)
-* Adds configuration for OpenAI prompt.
+- Adds configuration for OpenAI prompt.
   [#533](https://github.com/glebm/i18n-tasks/pull/533)
-* Adds configuration for OpenAI model.
+- Adds configuration for OpenAI model.
   [#532](https://github.com/glebm/i18n-tasks/pull/532) [#534](https://github.com/glebm/i18n-tasks/pull/534)
 
 ## v1.0.13
 
-* OpenAI translator.
+- OpenAI translator.
   [#519](https://github.com/glebm/i18n-tasks/pull/519)
-* DeepL
-  * More robust interpolation handling.
+- DeepL
+  - More robust interpolation handling.
     [#523](https://github.com/glebm/i18n-tasks/pull/523)
-  * Configurable formality level.
+  - Configurable formality level.
     [#477](https://github.com/glebm/i18n-tasks/pull/477)
-  * Send requests in batches.
+  - Send requests in batches.
     [#474](https://github.com/glebm/i18n-tasks/pull/474)
-* Support partially dynamic segments in non-strict mode (e.g. `t "cats.#{cat}-bio.name"`).
+- Support partially dynamic segments in non-strict mode (e.g. `t "cats.#{cat}-bio.name"`).
   [#509](https://github.com/glebm/i18n-tasks/pull/509)
-* Fixes `grep_keys` in Ruby 3+.
+- Fixes `grep_keys` in Ruby 3+.
   [#492](https://github.com/glebm/i18n-tasks/pull/492)
-* Improved handling of older libyaml versions.
+- Improved handling of older libyaml versions.
   [#493](https://github.com/glebm/i18n-tasks/pull/493)
 
 ## v1.0.12
 
-* The heuristic for detecting non-plural keys that look like plural keys has been removed
+- The heuristic for detecting non-plural keys that look like plural keys has been removed
   because it was causing other issues. Please use `ignore_missing` to handle such keys.
   [#461](https://github.com/glebm/i18n-tasks/issues/461)
-* Adds support for plural default values,
+- Adds support for plural default values,
   e.g. `t('test', default: { one: '1', other: '2' })`.
   [#464](https://github.com/glebm/i18n-tasks/issues/464)
-* Adds the `-p` pattern option to the `missing`, `add-missing`, and `translate-missing` commands.
+- Adds the `-p` pattern option to the `missing`, `add-missing`, and `translate-missing` commands.
   [#469](https://github.com/glebm/i18n-tasks/issues/469)
-* Relaxes version restriction for the `better_html` depedency to allow v2.x.
+- Relaxes version restriction for the `better_html` depedency to allow v2.x.
   [#471](https://github.com/glebm/i18n-tasks/pull/471)
-* Support filenames where locale is separated by a `-`, e.g. `user-en.yml` instead of the usual `user.en.yml`.
+- Support filenames where locale is separated by a `-`, e.g. `user-en.yml` instead of the usual `user.en.yml`.
   [#467](https://github.com/glebm/i18n-tasks/pull/467)
 
 ## v1.0.11
 
-* Fixes `--config` command line flag.
+- Fixes `--config` command line flag.
   [#455](https://github.com/glebm/i18n-tasks/pull/455)
 
-* Fixes circular `require` warnings on Ruby 3.1.2.
+- Fixes circular `require` warnings on Ruby 3.1.2.
   [#457](https://github.com/glebm/i18n-tasks/pull/457)
 
-* `*.xlsx` files are now excluded by default.
+- `*.xlsx` files are now excluded by default.
   [#458](https://github.com/glebm/i18n-tasks/pull/458)
 
 ## v1.0.10
 
-* Fixes `relative_exclude_method_name_paths`.
+- Fixes `relative_exclude_method_name_paths`.
   Previously, the code used `exclude_method_name_paths` instead of `relative_exclude_method_name_paths`.
   [#454](https://github.com/glebm/i18n-tasks/pull/454)
 
 ## v1.0.9
 
-* Adds an optional AST matcher for Rails model translations, such as `human_attribute_name`.
+- Adds an optional AST matcher for Rails model translations, such as `human_attribute_name`.
 
   Can be enabled by adding the following to the config:
 
@@ -89,164 +94,164 @@
 
 ## v1.0.8
 
-* Fixes a crash in `strict: false` mode.
+- Fixes a crash in `strict: false` mode.
   [#445](https://github.com/glebm/i18n-tasks/pull/445)
 
 ## v1.0.7
 
-* Fixes an issue with `scope:` argument parsing.
+- Fixes an issue with `scope:` argument parsing.
   [#442](https://github.com/glebm/i18n-tasks/pull/442)
 
 ## v1.0.6
 
-* Fixes handling of more types of ERB comments.
+- Fixes handling of more types of ERB comments.
   [#437](https://github.com/glebm/i18n-tasks/pull/437)
 
 ## v1.0.5
 
-* Fixes handling of multiline ERB comments.
+- Fixes handling of multiline ERB comments.
   [#431](https://github.com/glebm/i18n-tasks/issues/431)
 
 ## v1.0.4
 
-* Fixes handling of ERB comments without a space between `%` and `#` (`<%# ... %>`).
+- Fixes handling of ERB comments without a space between `%` and `#` (`<%# ... %>`).
   [#429](https://github.com/glebm/i18n-tasks/pull/429)
-* Better support for the `it` gem.
+- Better support for the `it` gem.
   [#361](https://github.com/glebm/i18n-tasks/issues/361)
 
 ## v1.0.3
 
-* Fixes inline block handling in ERB files.
+- Fixes inline block handling in ERB files.
   [#427](https://github.com/glebm/i18n-tasks/pull/427)
 
 ## v1.0.2
 
-* Fixes block call handling in ERB files.
+- Fixes block call handling in ERB files.
   [#425](https://github.com/glebm/i18n-tasks/pull/425)
 
 ## v1.0.1
 
-* Fixes `better_html` scanning the project.
+- Fixes `better_html` scanning the project.
   [#422](https://github.com/glebm/i18n-tasks/issues/422)
 
 ## v1.0.0
 
-* Log [#StandWithUkraine](https://stand-with-ukraine.pp.ua/) to stderr on every CLI command.
-* Improved ERB parsing: Replaces a regexp-based parser with an AST parser.
+- Log [#StandWithUkraine](https://stand-with-ukraine.pp.ua/) to stderr on every CLI command.
+- Improved ERB parsing: Replaces a regexp-based parser with an AST parser.
   [#416](https://github.com/glebm/i18n-tasks/pull/416)
-* Fixes compatibility with Psych 4.0+ and Ruby 3.1.
+- Fixes compatibility with Psych 4.0+ and Ruby 3.1.
   [#415](https://github.com/glebm/i18n-tasks/pull/415)
-* Works around an emoji handling bug in libyaml.
+- Works around an emoji handling bug in libyaml.
   [#421](https://github.com/glebm/i18n-tasks/pull/421)
 
 ## v0.9.37
 
-* Reverted `"#{hash["key"]}"` pattern scanner support because it caused a number of issues.
+- Reverted `"#{hash["key"]}"` pattern scanner support because it caused a number of issues.
   [#410](https://github.com/glebm/i18n-tasks/pull/410)
-* Drops support for Ruby < 2.6.
+- Drops support for Ruby < 2.6.
   [#2552cdb3](https://github.com/glebm/i18n-tasks/commit/2552cdb36a94a801e64d6b71279353dbbedb1618)
 
 ## v0.9.36
 
-* Fixes ActiveSupport 7 compatibility.
+- Fixes ActiveSupport 7 compatibility.
   [#403](https://github.com/glebm/i18n-tasks/pull/403)
-* Fixes mixed optional and keyword arguments in `I18n::Tasks::BaseTask.new`.
+- Fixes mixed optional and keyword arguments in `I18n::Tasks::BaseTask.new`.
   [#401](https://github.com/glebm/i18n-tasks/issues/401)
-* `*.map` files are now ignored by default.
+- `*.map` files are now ignored by default.
   [#399](https://github.com/glebm/i18n-tasks/pull/399)
-* `data` task now supports the `key-values` format that outputs a TSV.
+- `data` task now supports the `key-values` format that outputs a TSV.
   [#398](https://github.com/glebm/i18n-tasks/pull/398)
-* `"#{hash["key"]}"` interpolations are now supported in the pattern scanner.
+- `"#{hash["key"]}"` interpolations are now supported in the pattern scanner.
   [#397](https://github.com/glebm/i18n-tasks/pull/397) [#405](https://github.com/glebm/i18n-tasks/pull/405)
-* Forward slash (`/`) is now an allowed character in translation keys.
+- Forward slash (`/`) is now an allowed character in translation keys.
   [#396](https://github.com/glebm/i18n-tasks/pull/396)
 
 ## v0.9.35
 
-* New CLI argument `--config`, to specify the config file location.
+- New CLI argument `--config`, to specify the config file location.
   [#394](https://github.com/glebm/i18n-tasks/issues/394)
-* Allow relative keys in any Ruby object.
+- Allow relative keys in any Ruby object.
   [#381](https://github.com/glebm/i18n-tasks/issues/381)
-* Fix not ignoring missing for pluralization.
+- Fix not ignoring missing for pluralization.
   [#389](https://github.com/glebm/i18n-tasks/issues/389)
-* A more robust translation interpolation replacement token.
+- A more robust translation interpolation replacement token.
   [#392](https://github.com/glebm/i18n-tasks/pull/392)
-* Add `deepl_host` and `deepl_version` to translation config.
+- Add `deepl_host` and `deepl_version` to translation config.
   [#384](https://github.com/glebm/i18n-tasks/pull/384)
-* Add `*.jpeg` to the default ignore list.
+- Add `*.jpeg` to the default ignore list.
   [#382](https://github.com/glebm/i18n-tasks/pull/382)
 
 ## v0.9.34
 
-* Fixes Ruby 3.0 compatibility.
+- Fixes Ruby 3.0 compatibility.
   [#370](https://github.com/glebm/i18n-tasks/issues/370)
-* Drops support for Ruby < 2.5.
+- Drops support for Ruby < 2.5.
   [#e71a3bf](https://github.com/glebm/i18n-tasks/commit/e71a3bf37e46606aaaea1df81108f8e43aa4a5a1)
 
 ## v0.9.33
 
-* Fixes DeepL translation.
+- Fixes DeepL translation.
   [#367](https://github.com/glebm/i18n-tasks/pull/367)
 
 ## v0.9.32
 
-* Support capitalized region names in locale codes (e.g. "zh-YUE")
+- Support capitalized region names in locale codes (e.g. "zh-YUE")
   [#357](https://github.com/glebm/i18n-tasks/pull/357)
-* DeepL: Fix single value translation.
+- DeepL: Fix single value translation.
   [#d31297b5](https://github.com/glebm/i18n-tasks/commit/d31297b557687b022e4534927237e4dfd1fdfd23)
-* Fix missing key detection for external keys in non-base locale.
+- Fix missing key detection for external keys in non-base locale.
   [#364](https://github.com/glebm/i18n-tasks/issues/364)
-* `required_ruby_version`: Allow Ruby 3.x.
-* Fix deprecation warnings on Ruby 2.7.1.
+- `required_ruby_version`: Allow Ruby 3.x.
+- Fix deprecation warnings on Ruby 2.7.1.
   [#352](https://github.com/glebm/i18n-tasks/pull/352)
 
 ## v0.9.31
 
-* Add Yandex translator backend.
+- Add Yandex translator backend.
   [#343](https://github.com/glebm/i18n-tasks/pull/343)
-* Fix more Ruby 2.7 warnings.
+- Fix more Ruby 2.7 warnings.
   [#344](https://github.com/glebm/i18n-tasks/pull/344)
 
 ## v0.9.30
 
-* Fix keyword arguments warnings in Ruby 2.7.
+- Fix keyword arguments warnings in Ruby 2.7.
   [#342](https://github.com/glebm/i18n-tasks/pull/342)
-* Recognize `t!` and `translate!` methods.
+- Recognize `t!` and `translate!` methods.
   [#329](https://github.com/glebm/i18n-tasks/issues/329)
-* Test template now tests for inconsistent interpolations.
+- Test template now tests for inconsistent interpolations.
   [#317](https://github.com/glebm/i18n-tasks/pull/317)
 
 ## v0.9.29
 
-* The `remove_unused` command now supports `--pattern`.
+- The `remove_unused` command now supports `--pattern`.
   [#327](https://github.com/glebm/i18n-tasks/pull/327)
-* Common audio and video file extensions are now ignored.
+- Common audio and video file extensions are now ignored.
   [#324](https://github.com/glebm/i18n-tasks/issues/324)
-* The test templates for RSpec and minitest now include consistent interpolations check.
+- The test templates for RSpec and minitest now include consistent interpolations check.
   [#317](https://github.com/glebm/i18n-tasks/pull/317)
-* Leaf->tree expansion warnings are no longer issued for plural keys (where they are legal).
+- Leaf->tree expansion warnings are no longer issued for plural keys (where they are legal).
   [#314](https://github.com/glebm/i18n-tasks/pull/314)
-* Single line comments are now ignored in `.js` and `.es6` files.
+- Single line comments are now ignored in `.js` and `.es6` files.
   Magic comments are still supported (e.g. `// i18n-tasks-use I18n.t('hello')`).
   [#322](https://github.com/glebm/i18n-tasks/issues/322)
-* No longer loads all of `rails-i18n` and doesn't set `I18n.enforce_available_locales`,
+- No longer loads all of `rails-i18n` and doesn't set `I18n.enforce_available_locales`,
   fixing some compatibility issues introduced in v0.9.28.
   [#315](https://github.com/glebm/i18n-tasks/issues/315)
 
 ## v0.9.28
 
-* The `missing` command now also detects incomplete pluralizations.
+- The `missing` command now also detects incomplete pluralizations.
   [#308](https://github.com/glebm/i18n-tasks/issues/308)
 
 ## v0.9.27
 
-* Fixes `check-consistent-interpolations` when the same interpolation is used more than once.
+- Fixes `check-consistent-interpolations` when the same interpolation is used more than once.
 
 ## v0.9.26
 
-* `eq-base` command now returns a non-zero exit code if there are any results.
+- `eq-base` command now returns a non-zero exit code if there are any results.
   [#301](https://github.com/glebm/i18n-tasks/pull/301)
-* New command, `check-consistent-interpolations`, checks that %-interpolations across all locales are consistent.
+- New command, `check-consistent-interpolations`, checks that %-interpolations across all locales are consistent.
   The corresponding ignore setting is `ignore_inconsistent_interpolations`.
 
   This check also runs as part of the `health` command.
@@ -255,23 +260,23 @@
 
 ## v0.9.25
 
-* Adds an optional `--keep-order` (`-k`) parameter to `remove-unused`.
+- Adds an optional `--keep-order` (`-k`) parameter to `remove-unused`.
   When passed, keys in the files are not sorted after removing the unused keys.
   [#297](https://github.com/glebm/i18n-tasks/pull/297)
-* Drops support for Ruby < 2.3.
+- Drops support for Ruby < 2.3.
   [#298](https://github.com/glebm/i18n-tasks/pull/298)
-* Fixes a rare concurrency issue, most easily reproduced on Rubinius.
+- Fixes a rare concurrency issue, most easily reproduced on Rubinius.
   [#300](https://github.com/glebm/i18n-tasks/issues/300)
-* Avoid Google / DeepL translating empty keys (a minor optimization).
+- Avoid Google / DeepL translating empty keys (a minor optimization).
   [#fc529e78](https://github.com/glebm/i18n-tasks/commit/fc529e78d2421ad08e7a93c0164e5d0be1492e40)
 
 ## v0.9.24
 
-* Makes `deepl-rb` and `easy_translate` dependencies optional.
+- Makes `deepl-rb` and `easy_translate` dependencies optional.
   [#296](https://github.com/glebm/i18n-tasks/issues/296)
-* Adds DeepL support to `tree-translate`.
-* Removes the deprecated `tree-rename-key` command.
-* Removes obsolete XSLX report functionality.
+- Adds DeepL support to `tree-translate`.
+- Removes the deprecated `tree-rename-key` command.
+- Removes obsolete XSLX report functionality.
 
 ## v0.9.23
 
@@ -370,10 +375,10 @@ I18n::Tasks.add_scanner(
 
 ## v0.9.14
 
-* AST scanner: support nested `t` calls in ruby files.
+- AST scanner: support nested `t` calls in ruby files.
   [#c61f4e00](https://github.com/glebm/i18n-tasks/commit/c61f4e00ee67d7e9963ddb44ed3228f551cc1cad)
 
-* Exclude `*.swf` and `*.flv` files by default.
+- Exclude `*.swf` and `*.flv` files by default.
   [#233](https://github.com/glebm/i18n-tasks/issues/233)
 
 ## v0.9.13
@@ -387,25 +392,25 @@ and [fixing](https://github.com/glebm/i18n-tasks/pull/235) the issue!
 
 This is a minor bugfix release.
 
-* Do not warn about "adding children to leaf" for keys found in source.
+- Do not warn about "adding children to leaf" for keys found in source.
   [#228](https://github.com/glebm/i18n-tasks/pull/228)
-* Fix an issue with nested keys with the `scope` argument in views.
+- Fix an issue with nested keys with the `scope` argument in views.
   [#224](https://github.com/glebm/i18n-tasks/issues/224)
 
 ## v0.9.11
 
 This is a minor bugfix release.
 
-* Fixes another issue with the `scope` argument in views.
+- Fixes another issue with the `scope` argument in views.
   [#224](https://github.com/glebm/i18n-tasks/issues/224)
 
 ## v0.9.10
 
 This is a minor bugfix release.
 
-* Fixes parenthesized `t()` calls with a `scope` argument in views.
+- Fixes parenthesized `t()` calls with a `scope` argument in views.
   [#224](https://github.com/glebm/i18n-tasks/issues/224)
-* Fixes the `i18n-tasks irb` task.
+- Fixes the `i18n-tasks irb` task.
   [#222](https://github.com/glebm/i18n-tasks/issues/222)
 
 ## v0.9.9
@@ -431,404 +436,404 @@ This release adds the `mv` command for renaming/moving the keys.
 
 This is a minor bugfix release.
 
-* Fixed `add-missing` command ignoring the locales argument.
+- Fixed `add-missing` command ignoring the locales argument.
   [#205](https://github.com/glebm/i18n-tasks/issues/205)
-* Always require `PatternMapper` so that it doesn't need requiring in the config.
+- Always require `PatternMapper` so that it doesn't need requiring in the config.
   [#204](https://github.com/glebm/i18n-tasks/issues/204)
-* If `internal_locale` is set to a locale that's not available, reset it to `en` and print a warning.
+- If `internal_locale` is set to a locale that's not available, reset it to `en` and print a warning.
   [#202](https://github.com/glebm/i18n-tasks/issues/202)
 
 ## 0.9.6
 
 This is a minor bugfix release.
 
-* Fixes the `ignore_lines` PatternScanner feature. [#206](https://github.com/glebm/i18n-tasks/issues/206)
-* Allows `:` to be a part of the key. [#207](https://github.com/glebm/i18n-tasks/issues/207)
-* Fixes translation of plural HTML keys. [#193](https://github.com/glebm/i18n-tasks/issues/193)
+- Fixes the `ignore_lines` PatternScanner feature. [#206](https://github.com/glebm/i18n-tasks/issues/206)
+- Allows `:` to be a part of the key. [#207](https://github.com/glebm/i18n-tasks/issues/207)
+- Fixes translation of plural HTML keys. [#193](https://github.com/glebm/i18n-tasks/issues/193)
 
 ## 0.9.5
 
-* Add a `PatternMapper` scanner for mapping bits of code to keys [#191](https://github.com/glebm/i18n-tasks/issues/191).
-* Add missing keys with `nil` value by passing `--nil-value` to `add-missing`. [#170](https://github.com/glebm/i18n-tasks/issues/170)
-* Requiring `i18n-tasks` no longer overrides `I18n.locale`. [#190](https://github.com/glebm/i18n-tasks/issues/190).
+- Add a `PatternMapper` scanner for mapping bits of code to keys [#191](https://github.com/glebm/i18n-tasks/issues/191).
+- Add missing keys with `nil` value by passing `--nil-value` to `add-missing`. [#170](https://github.com/glebm/i18n-tasks/issues/170)
+- Requiring `i18n-tasks` no longer overrides `I18n.locale`. [#190](https://github.com/glebm/i18n-tasks/issues/190).
 
 ## 0.9.4
 
-* Improve reporting for reference keys throughout.
+- Improve reporting for reference keys throughout.
 
 ## 0.9.3
 
-* Support i18n `:symbol` reference keys. [#150](https://github.com/glebm/i18n-tasks/issues/150)
-* Fixes dynamic key matching issue with nested `#{}`. [#180](https://github.com/glebm/i18n-tasks/issues/180)
+- Support i18n `:symbol` reference keys. [#150](https://github.com/glebm/i18n-tasks/issues/150)
+- Fixes dynamic key matching issue with nested `#{}`. [#180](https://github.com/glebm/i18n-tasks/issues/180)
 
 ## 0.9.2
 
-* Fix ActiveSupport >= 4.0 but < 4.2 compatibility. [#178](https://github.com/glebm/i18n-tasks/issues/178)
-* Locale file path rewriting now matches locales as directories and multiple instances of the locale in the path. [#176](https://github.com/glebm/i18n-tasks/issues/176) [#177](https://github.com/glebm/i18n-tasks/issues/177)
+- Fix ActiveSupport >= 4.0 but < 4.2 compatibility. [#178](https://github.com/glebm/i18n-tasks/issues/178)
+- Locale file path rewriting now matches locales as directories and multiple instances of the locale in the path. [#176](https://github.com/glebm/i18n-tasks/issues/176) [#177](https://github.com/glebm/i18n-tasks/issues/177)
 
 ## 0.9.1
 
-* New method: `I18n::Tasks.add_scanner(scanner_class_name, scanner_opts)` to add a scanner to the default configuration.
-* New method: `I18n::Tasks.add_commands(commands_module)` to add commands to `i18n-tasks`.
-* Only match `I18n` or `nil` receivers in PatternScanner.
+- New method: `I18n::Tasks.add_scanner(scanner_class_name, scanner_opts)` to add a scanner to the default configuration.
+- New method: `I18n::Tasks.add_commands(commands_module)` to add commands to `i18n-tasks`.
+- Only match `I18n` or `nil` receivers in PatternScanner.
 
 ## 0.9.0
 
-* Support for multiple scanners.
-* AST scanner for `.rb` files.
-* `default:` argument support for `add-missing -v`. AST scanner only.  [#55](https://github.com/glebm/i18n-tasks/issues/55)
-* Recognize that only `t` calls can use relative keys, not `I18n.t`. AST scanner only. [#106](https://github.com/glebm/i18n-tasks/issues/106)
-* Strict mode enabled by default, can be configured via `search.strict`. New argument: `--no-strict`.
-* `search.include` renamed to `search.only`.
+- Support for multiple scanners.
+- AST scanner for `.rb` files.
+- `default:` argument support for `add-missing -v`. AST scanner only. [#55](https://github.com/glebm/i18n-tasks/issues/55)
+- Recognize that only `t` calls can use relative keys, not `I18n.t`. AST scanner only. [#106](https://github.com/glebm/i18n-tasks/issues/106)
+- Strict mode enabled by default, can be configured via `search.strict`. New argument: `--no-strict`.
+- `search.include` renamed to `search.only`.
 
 ## 0.8.7
 
-* New interpolation value for `add-missing -v`: `%{key}`. [Stijn Mathysen](https://github.com/stijnster) [#164](https://github.com/glebm/i18n-tasks/pull/164)
-* When adding keys from non-default locales, merge base locale first, then the others. [#162](https://github.com/glebm/i18n-tasks/issues/162)
+- New interpolation value for `add-missing -v`: `%{key}`. [Stijn Mathysen](https://github.com/stijnster) [#164](https://github.com/glebm/i18n-tasks/pull/164)
+- When adding keys from non-default locales, merge base locale first, then the others. [#162](https://github.com/glebm/i18n-tasks/issues/162)
 
 ## 0.8.6
 
-* Report missing keys found in source in all the locales. [#162](https://github.com/glebm/i18n-tasks/issues/162)
-* Fix `data-remove` task. [#140](https://github.com/glebm/i18n-tasks/issues/140)
-* Non-zero exit code on `health`, `missing`, and `unused` if such keys are present. [#151](https://github.com/glebm/i18n-tasks/issues/151)
-* XLSX report compatibility with the OSX Numbers App. [#159](https://github.com/glebm/i18n-tasks/issues/159)
-* RSpec template compatibility with `config.expose_dsl_globally = false`. [#148](https://github.com/glebm/i18n-tasks/issues/148)
-* `bundle show vagrant` example in the config template is no longer interpolated .[#161](https://github.com/glebm/i18n-tasks/issues/161)
+- Report missing keys found in source in all the locales. [#162](https://github.com/glebm/i18n-tasks/issues/162)
+- Fix `data-remove` task. [#140](https://github.com/glebm/i18n-tasks/issues/140)
+- Non-zero exit code on `health`, `missing`, and `unused` if such keys are present. [#151](https://github.com/glebm/i18n-tasks/issues/151)
+- XLSX report compatibility with the OSX Numbers App. [#159](https://github.com/glebm/i18n-tasks/issues/159)
+- RSpec template compatibility with `config.expose_dsl_globally = false`. [#148](https://github.com/glebm/i18n-tasks/issues/148)
+- `bundle show vagrant` example in the config template is no longer interpolated .[#161](https://github.com/glebm/i18n-tasks/issues/161)
 
 ## 0.8.5
 
-* Fix regression: Plugin support [#153](https://github.com/glebm/i18n-tasks/issues/153).
+- Fix regression: Plugin support [#153](https://github.com/glebm/i18n-tasks/issues/153).
 
 ## 0.8.4
 
-* Support relative keys in mailers [#155](https://github.com/glebm/i18n-tasks/issues/155).
+- Support relative keys in mailers [#155](https://github.com/glebm/i18n-tasks/issues/155).
 
 ## 0.8.3
 
-* Fix regression: ActiveSupport < 4 support [#143](https://github.com/glebm/i18n-tasks/issues/143).
+- Fix regression: ActiveSupport < 4 support [#143](https://github.com/glebm/i18n-tasks/issues/143).
 
 ## 0.8.2
 
-* Fix failure on nil values in the data config [#142](https://github.com/glebm/i18n-tasks/issues/142).
+- Fix failure on nil values in the data config [#142](https://github.com/glebm/i18n-tasks/issues/142).
 
 ## 0.8.1
 
-* The default config file now excludes `app/assets/images` and `app/assets/fonts`. Add `*.otf` to ignored extensions.
-* If an error message occurs when scanning, the error message now includes the filename [#141](https://github.com/glebm/i18n-tasks/issues/141).
+- The default config file now excludes `app/assets/images` and `app/assets/fonts`. Add `*.otf` to ignored extensions.
+- If an error message occurs when scanning, the error message now includes the filename [#141](https://github.com/glebm/i18n-tasks/issues/141).
 
 ## 0.8.0
 
-* Parse command line arguments with `optparse`. Remove dependency on Slop.
+- Parse command line arguments with `optparse`. Remove dependency on Slop.
   Simplified commands DSL: options are mostly passed directly to optparse.
-* `search.relative_roots` default changed from from `%w(app/views)` to
+- `search.relative_roots` default changed from from `%w(app/views)` to
   `%w(app/views app/controllers app/helpers app/presenters)`.
-* `add-missing` now adds keys detected in source to all locales (previously just base) [#134](https://github.com/glebm/i18n-tasks/issues/134).
-* The default spec template no long requires `spec_helper` by default [Daniel Levenson](https://github.com/dleve123) [#135](https://github.com/glebm/i18n-tasks/pull/135).
-* `search.exclude` now appends to and not overrides the default exclude list. More extensions excluded by default:
-  *.css, *.sass, *.scss, *.less, *.yml, and *.json. [#137](https://github.com/glebm/i18n-tasks/issues/137).
+- `add-missing` now adds keys detected in source to all locales (previously just base) [#134](https://github.com/glebm/i18n-tasks/issues/134).
+- The default spec template no long requires `spec_helper` by default [Daniel Levenson](https://github.com/dleve123) [#135](https://github.com/glebm/i18n-tasks/pull/135).
+- `search.exclude` now appends to and not overrides the default exclude list. More extensions excluded by default:
+  _.css, _.sass, _.scss, _.less, _.yml, and _.json. [#137](https://github.com/glebm/i18n-tasks/issues/137).
 
 ## 0.7.13
 
-* Fix relative keys when controller name consists of more than one word by [Yuji Nakayama](https://github.com/yujinakayama) [#132](https://github.com/glebm/i18n-tasks/pull/132).
-* Support keys with UTF8 word characters in the name. [#133](https://github.com/glebm/i18n-tasks/issues/133).
-* Change missing report column title from "Details" to "Value in other locales or source", display the locale [#130](https://github.com/glebm/i18n-tasks/issues/130).
+- Fix relative keys when controller name consists of more than one word by [Yuji Nakayama](https://github.com/yujinakayama) [#132](https://github.com/glebm/i18n-tasks/pull/132).
+- Support keys with UTF8 word characters in the name. [#133](https://github.com/glebm/i18n-tasks/issues/133).
+- Change missing report column title from "Details" to "Value in other locales or source", display the locale [#130](https://github.com/glebm/i18n-tasks/issues/130).
 
 ## 0.7.12
 
-* Handle relative keys in controllers nested in modules by [Alexander Tipugin](https://github.com/atipugin). [#128](https://github.com/glebm/i18n-tasks/issues/128).
-* Only write files that changed [#125](https://github.com/glebm/i18n-tasks/issues/125).
-* Allow `[]` in the non-strict scanner pattern [#127](https://github.com/glebm/i18n-tasks/issues/127).
+- Handle relative keys in controllers nested in modules by [Alexander Tipugin](https://github.com/atipugin). [#128](https://github.com/glebm/i18n-tasks/issues/128).
+- Only write files that changed [#125](https://github.com/glebm/i18n-tasks/issues/125).
+- Allow `[]` in the non-strict scanner pattern [#127](https://github.com/glebm/i18n-tasks/issues/127).
 
 ## 0.7.11
 
-* Set slop dependency to 3.5 to ensure Ruby 1.9 compatibility ([#121](https://github.com/glebm/i18n-tasks/pull/121)).
+- Set slop dependency to 3.5 to ensure Ruby 1.9 compatibility ([#121](https://github.com/glebm/i18n-tasks/pull/121)).
   MRI 1.9 EOL is [February 23, 2015](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/).
   We will support 1.9 until rbx and jruby support 2.0.
 
 ## 0.7.10
 
-* Support relative keys in controller action with argument
+- Support relative keys in controller action with argument
 
 ## 0.7.9
 
-* Support relative keys in Rails controller actions by [Jessie A. Young](https://github.com/jessieay). [#46](https://github.com/glebm/i18n-tasks/issues/46).
-* Minor fixes
+- Support relative keys in Rails controller actions by [Jessie A. Young](https://github.com/jessieay). [#46](https://github.com/glebm/i18n-tasks/issues/46).
+- Minor fixes
 
 ## 0.7.8
 
-* Fix Google Translate issues with non-string keys [#100](https://github.com/glebm/i18n-tasks/pull/100)
-* Fix an issue with certain HAML not being parsed [#96](https://github.com/glebm/i18n-tasks/issues/96) [#102](https://github.com/glebm/i18n-tasks/pull/102)
-* Fix other minor issues
+- Fix Google Translate issues with non-string keys [#100](https://github.com/glebm/i18n-tasks/pull/100)
+- Fix an issue with certain HAML not being parsed [#96](https://github.com/glebm/i18n-tasks/issues/96) [#102](https://github.com/glebm/i18n-tasks/pull/102)
+- Fix other minor issues
 
 ## 0.7.7
 
-* Fix regression: keys are sorted once again [#92](https://github.com/glebm/i18n-tasks/issues/92).
+- Fix regression: keys are sorted once again [#92](https://github.com/glebm/i18n-tasks/issues/92).
 
 ## 0.7.6
 
-* Add a post-install notice with setup commands
-* Fix a small typo in the config template [#91](https://github.com/glebm/i18n-tasks/pull/91).
-* Fix `find` crashing on relative keys (regression)
+- Add a post-install notice with setup commands
+- Fix a small typo in the config template [#91](https://github.com/glebm/i18n-tasks/pull/91).
+- Fix `find` crashing on relative keys (regression)
 
 ## 0.7.5
 
 Dynamic key usage inference fixes by [Mikko Koski](https://github.com/rap1ds):
 
-* Append `:` to keys ending with dot '.' (to scan `t('category.' + cat)` as `t('category.:')`)
-* Consider keys ending with `:` as match expressions
-* Make `@` a valid character for keys (to allow `t("category.#{@cat}"`)
+- Append `:` to keys ending with dot '.' (to scan `t('category.' + cat)` as `t('category.:')`)
+- Consider keys ending with `:` as match expressions
+- Make `@` a valid character for keys (to allow `t("category.#{@cat}"`)
 
 ## 0.7.4
 
-* Fix `add-missing --help`
-* Fix a minor issue with `health` [#88](https://github.com/glebm/i18n-tasks/issues/88)
+- Fix `add-missing --help`
+- Fix a minor issue with `health` [#88](https://github.com/glebm/i18n-tasks/issues/88)
 
 ## 0.7.3
 
-* New task `translate-tree`
-* Bugs fixed: [nil values and Google Translate](https://github.com/glebm/i18n-tasks/issues/85), [config file encoding issue](#82).
+- New task `translate-tree`
+- Bugs fixed: [nil values and Google Translate](https://github.com/glebm/i18n-tasks/issues/85), [config file encoding issue](#82).
 
 ## 0.7.2
 
-* i18n-tasks now analyses itself! `internal_locale` setting has been added, that controls i18n-tasks reporting language.
-English and Russian are available in this release.
+- i18n-tasks now analyses itself! `internal_locale` setting has been added, that controls i18n-tasks reporting language.
+  English and Russian are available in this release.
 
 ## 0.7.1
 
-* 1.9.3 compatibility
+- 1.9.3 compatibility
 
 ## 0.7.0
 
 New tasks:
 
-* `i18n-tasks health` to display missing and unused keys along with other information
-* `i18n-tasks tree-` to manipulate trees
-* `i18n-tasks data-` to look up and manipulate locale data
-* Better `help` for all commands
-* Minor bug fixes
+- `i18n-tasks health` to display missing and unused keys along with other information
+- `i18n-tasks tree-` to manipulate trees
+- `i18n-tasks data-` to look up and manipulate locale data
+- Better `help` for all commands
+- Minor bug fixes
 
 Internally:
 
-* Refactored commands DSL
-* `add-missing`, `remove-unused` implemented in terms of the new `tree-` commands
+- Refactored commands DSL
+- `add-missing`, `remove-unused` implemented in terms of the new `tree-` commands
 
 ## 0.6.3
 
-* Strict mode added for `unused` and `remove-unused`. When passed `-s` or `--strict`, these tasks will not attempt to infer dynamic key usages, such as `t("category.#{category.key}")`.
-* Arrays are now supported as values for Google Translate [#77](https://github.com/glebm/i18n-tasks/issues/77)
+- Strict mode added for `unused` and `remove-unused`. When passed `-s` or `--strict`, these tasks will not attempt to infer dynamic key usages, such as `t("category.#{category.key}")`.
+- Arrays are now supported as values for Google Translate [#77](https://github.com/glebm/i18n-tasks/issues/77)
 
 ## 0.6.2
 
-* New task to show locale data: `i18n-tasks data`
-* New output format: `keys`, e.g. `i18n-tasks data -fkeys`
-* Fix an issue with a top-level dynamic key breaking unused detection [#75](https://github.com/glebm/i18n-tasks/issues/75)
-* Document [magic comment hints](https://github.com/glebm/i18n-tasks#fine-tuning)
+- New task to show locale data: `i18n-tasks data`
+- New output format: `keys`, e.g. `i18n-tasks data -fkeys`
+- Fix an issue with a top-level dynamic key breaking unused detection [#75](https://github.com/glebm/i18n-tasks/issues/75)
+- Document [magic comment hints](https://github.com/glebm/i18n-tasks#fine-tuning)
 
 ## 0.6.1
 
-* Fix Google Translate issue with plural keys and missing billing info error
+- Fix Google Translate issue with plural keys and missing billing info error
 
 ## 0.6.0
 
-* New output format options for reports: yaml, json, and inspect.
-* Templates for config and rspec.
-* Keys with values same as base locale have been moved from `missing` into a separate task, `eq-base`.
-* `missing` now also shows keys that are present in some locale but not in base locale.
-* Terminal output: no more Type column in `missing`, first code usage shown for keys missing base value.
-* `relative_roots` configuration key moved to `search.relative_roots`, deprecation warning (removed in the next minor).
+- New output format options for reports: yaml, json, and inspect.
+- Templates for config and rspec.
+- Keys with values same as base locale have been moved from `missing` into a separate task, `eq-base`.
+- `missing` now also shows keys that are present in some locale but not in base locale.
+- Terminal output: no more Type column in `missing`, first code usage shown for keys missing base value.
+- `relative_roots` configuration key moved to `search.relative_roots`, deprecation warning (removed in the next minor).
 
 ## 0.5.4
 
-* ActiveSupport 3 compatibility
+- ActiveSupport 3 compatibility
 
 ## 0.5.3
 
-* Fix Google translate regression
-* More robust config output
+- Fix Google translate regression
+- More robust config output
 
 ## 0.5.2
 
-* Ignore lines during search with `config.search.ignore_lines`. Ignores comments by default.
-* Fixed minor issues with `i18-tasks config` output.
+- Ignore lines during search with `config.search.ignore_lines`. Ignores comments by default.
+- Fixed minor issues with `i18-tasks config` output.
 
 ## 0.5.1
 
-* Fix [conservative router](https://github.com/glebm/i18n-tasks#conservative-router).
-* Conservative router is now the default.
+- Fix [conservative router](https://github.com/glebm/i18n-tasks#conservative-router).
+- Conservative router is now the default.
 
 ## 0.5.0
 
-* internals refactored to use trees everywhere
-* type `guide` in `i18n-tasks irb` to learn more about the commands
-* (remove-)unused tasks now work per locale
-* `ignore` settings are shown on `i18n-tasks config`
-* Rubinius 2.2.7 compatibility
+- internals refactored to use trees everywhere
+- type `guide` in `i18n-tasks irb` to learn more about the commands
+- (remove-)unused tasks now work per locale
+- `ignore` settings are shown on `i18n-tasks config`
+- Rubinius 2.2.7 compatibility
 
 ## 0.4.5
 
-* Respect tty color setting
+- Respect tty color setting
 
 ## 0.4.4
 
-* Fix google translate issues with plural keys and translating from non-base locale
+- Fix google translate issues with plural keys and translating from non-base locale
 
 ## 0.4.3
 
-* Ruby 1.9 compatibility
+- Ruby 1.9 compatibility
 
 ## 0.4.2
 
-* Ruby 1.9.3-compatible again
+- Ruby 1.9.3-compatible again
 
 ## 0.4.1
 
-* Improved error messages across the board
-* Fixed google translate issue with _html keys [#67](https://github.com/glebm/i18n-tasks/issues/67).
+- Improved error messages across the board
+- Fixed google translate issue with \_html keys [#67](https://github.com/glebm/i18n-tasks/issues/67).
 
 ## 0.4.0
 
-* In addition to pattern router, a new conservative router that keeps the keys in place. (See [#57](https://github.com/glebm/i18n-tasks/issues/57))
-* `i18n-tasks irb` for debugging
-* This release is a major refactoring to use real trees internally (as opposed to nested hashes).
-Real trees allow for much easier [traversal](/lib/i18n/tasks/data/tree/traversal.rb).
-With these trees, information can be associated with each node, which allows for things like the conservative router.
-* Accept keys with dashes (`-`) [#64](https://github.com/glebm/i18n-tasks/issues/64).
+- In addition to pattern router, a new conservative router that keeps the keys in place. (See [#57](https://github.com/glebm/i18n-tasks/issues/57))
+- `i18n-tasks irb` for debugging
+- This release is a major refactoring to use real trees internally (as opposed to nested hashes).
+  Real trees allow for much easier [traversal](/lib/i18n/tasks/data/tree/traversal.rb).
+  With these trees, information can be associated with each node, which allows for things like the conservative router.
+- Accept keys with dashes (`-`) [#64](https://github.com/glebm/i18n-tasks/issues/64).
 
 ## 0.3.11
 
-* Improve plural key handling
+- Improve plural key handling
 
 ## 0.3.10
 
-* New (de)serialization options in config
-* `add-missing` placeholder argument can now use %{base_value}.
+- New (de)serialization options in config
+- `add-missing` placeholder argument can now use %{base_value}.
 
 ## 0.3.9
 
-* Fix regression: Remove ActiveSupport::HashWithIndifferentAccess from locale data output
+- Fix regression: Remove ActiveSupport::HashWithIndifferentAccess from locale data output
 
 ## 0.3.8
 
-* Fix activesupport ~3.x compatibility issue (#45).
+- Fix activesupport ~3.x compatibility issue (#45).
 
 ## 0.3.7
 
-* Catch Errno::EPIPE to allow `i18n-tasks <command> | head` for large reports
-* Improved i18n-tasks config output
+- Catch Errno::EPIPE to allow `i18n-tasks <command> | head` for large reports
+- Improved i18n-tasks config output
 
 ## v0.3.6
 
-* fix issue with Google Translate
+- fix issue with Google Translate
 
 ## v0.3.5
 
-* `config.locales` is now picked up by default from paths do data files. `base_locale` defaults to `en`.
+- `config.locales` is now picked up by default from paths do data files. `base_locale` defaults to `en`.
 
 ## v0.3.3..v0.3.4
 
-* Bugfixes
+- Bugfixes
 
 ## v0.3.2
 
-* Tasks that accept locales now accept them as the first argument(s)
+- Tasks that accept locales now accept them as the first argument(s)
 
 ## v0.3.0
 
-* i18n-tasks is a binary now (instead of rake tasks). All tasks / commands now accept various options, and there is no need for as many of them as before.
-* Works faster on Rails as it doesn't load anything but the gem, but now requires `base_locale` and `locales` to be set in config.
+- i18n-tasks is a binary now (instead of rake tasks). All tasks / commands now accept various options, and there is no need for as many of them as before.
+- Works faster on Rails as it doesn't load anything but the gem, but now requires `base_locale` and `locales` to be set in config.
 
 ## v0.2.21..v0.2.22
 
-* `rake i18n:usages[pattern]`
-* performance regression fixes
+- `rake i18n:usages[pattern]`
+- performance regression fixes
 
 ## v0.2.20
 
-* `rake i18n:usages` report
+- `rake i18n:usages` report
 
 ## v0.2.17..v0.2.19
 
-* Bugfixes
+- Bugfixes
 
 ## v0.2.16
 
-* Key search extracted into its own class, and a custom scanner can now be provided.
-* Removed support for deprecated settings
+- Key search extracted into its own class, and a custom scanner can now be provided.
+- Removed support for deprecated settings
 
 ## v0.2.15
 
-* More robust I18n.t call detection (detect I18n.translate and multiline calls)
+- More robust I18n.t call detection (detect I18n.translate and multiline calls)
 
 ## v0.2.14
 
-* Google Translate fixes: preserve interpolations, set correct format based on the key (text or html).
+- Google Translate fixes: preserve interpolations, set correct format based on the key (text or html).
 
 ## v0.2.13
 
-* New setting relative_roots for relative key resolution (default: %w(app/views))
-* fix google translation attempts to translate non-string keys
+- New setting relative_roots for relative key resolution (default: %w(app/views))
+- fix google translation attempts to translate non-string keys
 
 ## v0.2.11 .. v0.2.12
 
-* New task: `i18n:remove_unused`
+- New task: `i18n:remove_unused`
 
 ## v0.2.5..0.2.10
 
-* config/i18n-tasks.yml now processed with ERB
-* can now be used with any ruby apps, not just Rails
-* more locale formats are considered valid
-* `i18n:missing` accepts locales
-* `i18n:missing` supports plural keys
+- config/i18n-tasks.yml now processed with ERB
+- can now be used with any ruby apps, not just Rails
+- more locale formats are considered valid
+- `i18n:missing` accepts locales
+- `i18n:missing` supports plural keys
 
 ## v0.2.4
 
-* more powerful key pattern matching with sets and backtracking
+- more powerful key pattern matching with sets and backtracking
 
 ## v0.2.3
 
-* spreadsheet report, tests run on rbx
+- spreadsheet report, tests run on rbx
 
 ## v0.2.2
 
-* improved output with terminal-table
+- improved output with terminal-table
 
 ## v0.2.1
 
-* fill tasks renamed, fix symbol key search
+- fill tasks renamed, fix symbol key search
 
 ## v0.2.0
 
-* 3 more prefill tasks, including Google Translate
-* tasks renamed
+- 3 more prefill tasks, including Google Translate
+- tasks renamed
 
 ## v0.1.8
 
-* improved search: no longer uses grep, more robust detection (@natano)
+- improved search: no longer uses grep, more robust detection (@natano)
 
 ## v0.1.7
 
-* ability to route prefill output via data.write config
-* multiple configuration variables renamed (still understands old syntax with deprecation warnings)
+- ability to route prefill output via data.write config
+- multiple configuration variables renamed (still understands old syntax with deprecation warnings)
 
 ## v0.1.6
 
-* New key pattern syntax for i18n-tasks.yml a la globbing
+- New key pattern syntax for i18n-tasks.yml a la globbing
 
 ## v0.1.5
 
-* Removed get_locale_data, added data configuration options
+- Removed get_locale_data, added data configuration options
 
 ## v0.1.4
 
-* Fix relative keys in partials (@paulfioravanti)
-* Fix i18n:missing when nothing is missing (@tamtamchik)
+- Fix relative keys in partials (@paulfioravanti)
+- Fix i18n:missing when nothing is missing (@tamtamchik)
 
 ## v0.1.3
 
-* detect countable keys as used for unused task
-* account for non-string keys coming from yaml (thanks @lichtamberg)
+- detect countable keys as used for unused task
+- account for non-string keys coming from yaml (thanks @lichtamberg)
 
 ## v0.1.2
 
-* added grep config options (thanks @dmke)
-* improved terminal output
+- added grep config options (thanks @dmke)
+- improved terminal output

--- a/lib/i18n/tasks/scanners/pattern_scanner.rb
+++ b/lib/i18n/tasks/scanners/pattern_scanner.rb
@@ -12,7 +12,7 @@ module I18n::Tasks::Scanners
     include OccurrenceFromPosition
     include RubyKeyLiterals
 
-    TRANSLATE_CALL_RE = /(?<=^|[^\p{L}'\-.]|[^\p{L}'-]I18n\.|I18n\.)t(?:!|ranslate!?)?/.freeze
+    TRANSLATE_CALL_RE = /(?<=^|[^\p{L}_'\-.]|[^\p{L}'-]I18n\.|I18n\.)t(?:!|ranslate!?)?/.freeze
     IGNORE_LINES = {
       'coffee' => /^\s*#(?!\si18n-tasks-use)/,
       'erb' => /^\s*<%\s*#(?!\si18n-tasks-use)/,

--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -21,8 +21,8 @@ module I18n::Tasks
       relative_roots: %w[app/controllers app/helpers app/mailers app/presenters app/views].freeze,
       scanners: [
         ['::I18n::Tasks::Scanners::RubyAstScanner', { only: %w[*.rb] }],
-        ['::I18n::Tasks::Scanners::ErbAstScanner', { only: %w[*.html.erb] }],
-        ['::I18n::Tasks::Scanners::PatternWithScopeScanner', { exclude: %w[*.html.erb *.rb] }]
+        ['::I18n::Tasks::Scanners::ErbAstScanner', { only: %w[*.erb] }],
+        ['::I18n::Tasks::Scanners::PatternWithScopeScanner', { exclude: %w[*.erb *.rb] }]
       ],
       ast_matchers: [],
       strict: true

--- a/spec/fixtures/app/views/ignore.js.erb
+++ b/spec/fixtures/app/views/ignore.js.erb
@@ -1,2 +1,0 @@
-// This is javascript file
-<% # i18n-tasks-use t('hello.world') %>

--- a/spec/fixtures/app/views/show.js.erb
+++ b/spec/fixtures/app/views/show.js.erb
@@ -1,0 +1,2 @@
+// This is javascript file
+<% # i18n-tasks-use t('hello.world.from_javascript') %>

--- a/spec/fixtures/used_keys/app/views/application/index.text.erb
+++ b/spec/fixtures/used_keys/app/views/application/index.text.erb
@@ -1,13 +1,13 @@
-<div id=first><%= t('a') %></div>
-<% what = t 'a' %>
-I18n.t("this_should_not")
-<h2>
+<%= t('text.a') %>
+<% what = t 'text.a' %>
+I18n.t("text.this_should_not")
+
   <% # i18n-tasks-use t('comment.absolute.attribute') %>
   <%= Translate.absolute.attribute %>
   <%= MeetingNote.model_name.human(count: 1) %>
   <%= AgendaItem.human_attribute_name(:title) %>
-</h2>
-<h3>
+
+
   <%= t('with_parameter', parameter: "erb is the best") %>
   <%= t 'with_scope', scope: "scope_a.scope_b", default: t(".nested_call") %>
 
@@ -25,4 +25,3 @@ I18n.t("this_should_not")
 
   <% # https://github.com/glebm/i18n-tasks/issues/572 %>
   <%= theme_t "ignore.this.one" %>
-</h3>

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe 'i18n-tasks' do
         .not_relative
         scope.subscope.a.b
         scope.key_in_erb
+        hello.world.from_javascript
         scope.relative.index.title
         reference-missing-target.a
         nested.parent.rb

--- a/spec/pattern_scanner_spec.rb
+++ b/spec/pattern_scanner_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'PatternScanner' do
       end
     end
 
-    ["t \"a.b'", 't a.b'].each do |string|
+    ["t \"a.b'", 't a.b', 'theme_t "a.b."'].each do |string|
       it "does not match #{string}" do
         expect(pattern).not_to match string
       end

--- a/spec/support/keys_and_occurrences.rb
+++ b/spec/support/keys_and_occurrences.rb
@@ -2,9 +2,21 @@
 
 module KeysAndOccurrences
   # rubocop:disable Metrics/ParameterLists
-  def make_occurrence(path: '', line: '', pos: 1, line_pos: 1, line_num: 1, raw_key: nil)
+  def make_occurrence(
+    path: '',
+    line: '',
+    pos: 1,
+    line_pos: 1,
+    line_num: 1,
+    raw_key: nil
+  )
     ::I18n::Tasks::Scanners::Results::Occurrence.new(
-      path: path, line: line, pos: pos, line_pos: line_pos, line_num: line_num, raw_key: raw_key
+      path: path,
+      line: line,
+      pos: pos,
+      line_pos: line_pos,
+      line_num: line_num,
+      raw_key: raw_key
     )
   end
   # rubocop:enable Metrics/ParameterLists
@@ -14,7 +26,10 @@ module KeysAndOccurrences
   end
 
   def make_key_occurrences(key, occurrences)
-    ::I18n::Tasks::Scanners::Results::KeyOccurrences.new(key: key, occurrences: make_occurrences(occurrences))
+    ::I18n::Tasks::Scanners::Results::KeyOccurrences.new(
+      key: key,
+      occurrences: make_occurrences(occurrences)
+    )
   end
 
   # adjust position to account for \r on Windows
@@ -28,6 +43,26 @@ module KeysAndOccurrences
 
   # adjust position to account for \r on Windows
   def adjust_occurrence(occurrence)
-    occurrence.dup.tap { |o| o.instance_variable_set(:@pos, o.pos + o.line_num - 1) }
+    occurrence.dup.tap do |o|
+      o.instance_variable_set(:@pos, o.pos + o.line_num - 1)
+    end
+  end
+
+  def leaves_to_hash(leaves)
+    leaves.to_h { |leaf| [leaf.full_key(root: false), leaf] }
+  end
+
+  def expected_occurrences(leaves, expected)
+    expect(leaves.keys).to match_array(expected.keys)
+    leaves.each do |key, leaf|
+      expected_data = expected[key]
+      occurrences = leaf.data[:occurrences]
+      expect(occurrences).not_to be_nil
+      expect(occurrences.size).to(eq(expected_data.size))
+
+      occurrences_to_compare =
+        occurrences.map { |occ| { path: occ.path, line_num: occ.line_num } }
+      expect(occurrences_to_compare).to(match_array(expected_data))
+    end
   end
 end

--- a/spec/used_keys_erb_spec.rb
+++ b/spec/used_keys_erb_spec.rb
@@ -20,314 +20,438 @@ RSpec.describe 'UsedKeysErb' do
     TestCodebase.in_test_app_dir(directory: 'spec/fixtures/used_keys') { ex.run }
   end
 
-  it '#used_keys' do
-    used_keys = task.used_tree
-    expect(used_keys.size).to eq(1)
-    leaves = used_keys.leaves.to_a
-    expect(leaves.size).to eq(9)
-
-    expect_node_key_data(
-      leaves[0],
-      'a',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 18,
-            line_num: 1, line_pos: 18,
-            line: "<div id=first><%= t('a') %></div>",
-            raw_key: 'a'
-          },
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 44,
-            line_num: 2, line_pos: 10,
-            line: "<% what = t 'a' %>",
-            raw_key: 'a'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[1],
-      'activerecord.models.meeting_note',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 185,
-            line_num: 7, line_pos: 6,
-            line: '  <%= MeetingNote.model_name.human(count: 1) %>',
-            raw_key: 'activerecord.models.meeting_note'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[2],
-      'activerecord.attributes.agenda_item.title',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 233,
-            line_num: 8, line_pos: 6,
-            line: '  <%= AgendaItem.human_attribute_name(:title) %>',
-            raw_key: 'activerecord.attributes.agenda_item.title'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[3],
-      'with_parameter',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 293,
-            line_num: 11, line_pos: 6,
-            line: "  <%= t('with_parameter', parameter: \"erb is the best\") %>",
-            raw_key: 'with_parameter'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[4],
-      'scope_a.scope_b.with_scope',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 352,
-            line_num: 12, line_pos: 6,
-            line: "  <%= t 'with_scope', scope: \"scope_a.scope_b\", default: t(\".nested_call\") %>",
-            raw_key: 'scope_a.scope_b.with_scope'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[5],
-      'application.show.nested_call',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 403,
-            line_num: 12, line_pos: 57,
-            line: "  <%= t 'with_scope', scope: \"scope_a.scope_b\", default: t(\".nested_call\") %>",
-            raw_key: '.nested_call'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[6],
-      'application.show.edit',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 523,
-            line_num: 15, line_pos: 41,
-            line: '  <%= link_to(edit_foo_path(foo), title: t(".edit")) do %>',
-            raw_key: '.edit'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[7],
-      'blacklight.tools.citation',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 745,
-            line_num: 21, line_pos: 25,
-            line: "    <% component.title { t('blacklight.tools.citation') } %>",
-            raw_key: 'blacklight.tools.citation'
-          }
-        ]
-      )
-    )
-
-    expect_node_key_data(
-      leaves[8],
-      'comment.absolute.attribute',
-      occurrences: make_occurrences(
-        [
-          {
-            path: 'app/views/application/show.html.erb',
-            pos: 147,
-            line_num: 6, line_pos: 6,
-            line: '  <%= Translate.absolute.attribute %>',
-            raw_key: 'comment.absolute.attribute'
-          }
-        ]
-      )
-    )
-  end
-
-  describe 'comments' do
-    let(:paths) do
-      %w[app/views/application/comments.html.erb]
-    end
+  describe '.text.erb' do
+    let(:paths) { %w[app/views/application/index.text.erb] }
 
     it '#used_keys' do
       used_keys = task.used_tree
       expect(used_keys.size).to eq(1)
+      leaves = leaves_to_hash(used_keys.leaves.to_a)
+
+      expect(leaves.keys).to match_array(
+        %w[
+          text.a
+          with_parameter
+          scope_a.scope_b.with_scope
+          application.index.nested_call
+          application.index.edit
+          blacklight.tools.citation
+          comment.absolute.attribute
+          activerecord.attributes.agenda_item.title
+          activerecord.models.meeting_note
+        ]
+      )
+
+      expected_occurrences(
+        leaves,
+        {
+          'text.a' => [
+            { path: 'app/views/application/index.text.erb', line_num: 1 },
+            { path: 'app/views/application/index.text.erb', line_num: 2 }
+          ],
+          'with_parameter' => [
+            { path: 'app/views/application/index.text.erb', line_num: 11 }
+          ],
+          'scope_a.scope_b.with_scope' => [
+            { path: 'app/views/application/index.text.erb', line_num: 12 }
+          ],
+          'application.index.nested_call' => [
+            { path: 'app/views/application/index.text.erb', line_num: 12 }
+          ],
+          'application.index.edit' => [
+            { path: 'app/views/application/index.text.erb', line_num: 15 }
+          ],
+          'blacklight.tools.citation' => [
+            { path: 'app/views/application/index.text.erb', line_num: 21 }
+          ],
+          'comment.absolute.attribute' => [
+            { path: 'app/views/application/index.text.erb', line_num: 6 }
+          ],
+          'activerecord.attributes.agenda_item.title' => [
+            { path: 'app/views/application/index.text.erb', line_num: 8 }
+          ],
+          'activerecord.models.meeting_note' => [
+            { path: 'app/views/application/index.text.erb', line_num: 7 }
+          ]
+        }
+      )
+    end
+  end
+
+  describe '.html.erb' do
+    let(:paths) { %w[app/views/application/show.html.erb] }
+
+    it '#used_keys' do # rubocop:disable RSpec/ExampleLength
+      used_keys = task.used_tree
+      expect(used_keys.size).to eq(1)
       leaves = used_keys.leaves.to_a
-      expect(leaves.size).to eq(8)
+      leaves_as_hash = leaves_to_hash(leaves)
+      expect(leaves_as_hash.keys).to match_array(
+        %w[
+          a
+          with_parameter
+          scope_a.scope_b.with_scope
+          application.show.nested_call
+          application.show.edit
+          blacklight.tools.citation
+          comment.absolute.attribute
+          activerecord.attributes.agenda_item.title
+          activerecord.models.meeting_note
+        ]
+      )
 
       expect_node_key_data(
         leaves[0],
-        'ruby.comment.works',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 139,
-              line_num: 5, line_pos: 4,
-              line: '<%= Translate.ruby_comment_works %>',
-              raw_key: 'ruby.comment.works'
-            }
-          ]
-        )
+        'a',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 18,
+                line_num: 1,
+                line_pos: 18,
+                line: "<div id=first><%= t('a') %></div>",
+                raw_key: 'a'
+              },
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 44,
+                line_num: 2,
+                line_pos: 10,
+                line: "<% what = t 'a' %>",
+                raw_key: 'a'
+              }
+            ]
+          )
       )
 
       expect_node_key_data(
         leaves[1],
-        'erb.comment.works',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 221,
-              line_num: 8, line_pos: 4,
-              line: '<%= Translate.erb_comment_works %>',
-              raw_key: 'erb.comment.works'
-            }
-          ]
-        )
+        'activerecord.models.meeting_note',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 185,
+                line_num: 7,
+                line_pos: 6,
+                line: '  <%= MeetingNote.model_name.human(count: 1) %>',
+                raw_key: 'activerecord.models.meeting_note'
+              }
+            ]
+          )
       )
 
       expect_node_key_data(
         leaves[2],
-        'erb_multi.comment.line1',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 352,
-              line_num: 12, line_pos: 4,
-              line: '<%= t("erb_multi.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
-              raw_key: 'erb_multi.comment.line1'
-            }
-          ]
-        )
+        'activerecord.attributes.agenda_item.title',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 233,
+                line_num: 8,
+                line_pos: 6,
+                line: '  <%= AgendaItem.human_attribute_name(:title) %>',
+                raw_key: 'activerecord.attributes.agenda_item.title'
+              }
+            ]
+          )
       )
 
-      # Will match the same row as leaves[2] for now
       expect_node_key_data(
         leaves[3],
-        'erb_multi.comment.line2',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 352,
-              line_num: 12, line_pos: 4,
-              line: '<%= t("erb_multi.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
-              raw_key: 'erb_multi.comment.line2'
-            }
-          ]
-        )
+        'with_parameter',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 293,
+                line_num: 11,
+                line_pos: 6,
+                line:
+                  "  <%= t('with_parameter', parameter: \"erb is the best\") %>",
+                raw_key: 'with_parameter'
+              }
+            ]
+          )
       )
 
       expect_node_key_data(
         leaves[4],
-        'erb_multi_dash.comment.line1',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 498,
-              line_num: 17, line_pos: 4,
-              line: '<%= t("erb_multi_dash.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
-              raw_key: 'erb_multi_dash.comment.line1'
-            }
-          ]
-        )
+        'scope_a.scope_b.with_scope',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 352,
+                line_num: 12,
+                line_pos: 6,
+                line:
+                  "  <%= t 'with_scope', scope: \"scope_a.scope_b\", default: t(\".nested_call\") %>",
+                raw_key: 'scope_a.scope_b.with_scope'
+              }
+            ]
+          )
       )
 
       expect_node_key_data(
         leaves[5],
-        'erb_multi_dash.comment.line2',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 498,
-              line_num: 17, line_pos: 4,
-              line: '<%= t("erb_multi_dash.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
-              raw_key: 'erb_multi_dash.comment.line2'
-            }
-          ]
-        )
+        'application.show.nested_call',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 403,
+                line_num: 12,
+                line_pos: 57,
+                line:
+                  "  <%= t 'with_scope', scope: \"scope_a.scope_b\", default: t(\".nested_call\") %>",
+                raw_key: '.nested_call'
+              }
+            ]
+          )
       )
 
       expect_node_key_data(
         leaves[6],
-        'ruby_multi.comment.line1',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 642,
-              line_num: 22, line_pos: 4,
-              line: '<%= t("ruby_multi.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
-              raw_key: 'ruby_multi.comment.line1'
-            }
-          ]
-        )
+        'application.show.edit',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 523,
+                line_num: 15,
+                line_pos: 41,
+                line:
+                  '  <%= link_to(edit_foo_path(foo), title: t(".edit")) do %>',
+                raw_key: '.edit'
+              }
+            ]
+          )
       )
 
       expect_node_key_data(
         leaves[7],
-        'ruby_multi.comment.line2',
-        occurrences: make_occurrences(
-          [
-            {
-              path: 'app/views/application/comments.html.erb',
-              pos: 588,
-              line_num: 21, line_pos: 0,
-              line: "# i18n-tasks-use t('ruby_multi.comment.line2') %>",
-              raw_key: 'ruby_multi.comment.line2'
-            }
-          ]
-        )
+        'blacklight.tools.citation',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 745,
+                line_num: 21,
+                line_pos: 25,
+                line:
+                  "    <% component.title { t('blacklight.tools.citation') } %>",
+                raw_key: 'blacklight.tools.citation'
+              }
+            ]
+          )
+      )
+
+      expect_node_key_data(
+        leaves[8],
+        'comment.absolute.attribute',
+        occurrences:
+          make_occurrences(
+            [
+              {
+                path: 'app/views/application/show.html.erb',
+                pos: 147,
+                line_num: 6,
+                line_pos: 6,
+                line: '  <%= Translate.absolute.attribute %>',
+                raw_key: 'comment.absolute.attribute'
+              }
+            ]
+          )
       )
     end
-  end
 
-  describe 'without rails_model matcher' do
-    let(:ast_matchers) { [] }
+    describe 'without rails_model matcher' do
+      let(:ast_matchers) { [] }
 
-    it '#used_keys' do
-      used_keys = task.used_tree
-      expect(used_keys.size).to eq(1)
-      leaves = used_keys.leaves.to_a
-      expect(leaves.size).to(eq(7))
+      it '#used_keys' do
+        used_keys = task.used_tree
+        expect(used_keys.size).to eq(1)
+        leaves = leaves_to_hash(used_keys.leaves.to_a)
+
+        expect(leaves.keys).to match_array(
+          %w[
+            a
+            with_parameter
+            scope_a.scope_b.with_scope
+            application.show.nested_call
+            application.show.edit
+            blacklight.tools.citation
+            comment.absolute.attribute
+          ]
+        )
+      end
+    end
+
+    describe 'comments' do
+      let(:paths) { %w[app/views/application/comments.html.erb] }
+
+      it '#used_keys' do
+        used_keys = task.used_tree
+        expect(used_keys.size).to eq(1)
+        leaves = used_keys.leaves.to_a
+        expect(leaves.size).to eq(8)
+
+        expect_node_key_data(
+          leaves[0],
+          'ruby.comment.works',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 139,
+                  line_num: 5,
+                  line_pos: 4,
+                  line: '<%= Translate.ruby_comment_works %>',
+                  raw_key: 'ruby.comment.works'
+                }
+              ]
+            )
+        )
+
+        expect_node_key_data(
+          leaves[1],
+          'erb.comment.works',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 221,
+                  line_num: 8,
+                  line_pos: 4,
+                  line: '<%= Translate.erb_comment_works %>',
+                  raw_key: 'erb.comment.works'
+                }
+              ]
+            )
+        )
+
+        expect_node_key_data(
+          leaves[2],
+          'erb_multi.comment.line1',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 352,
+                  line_num: 12,
+                  line_pos: 4,
+                  line: '<%= t("erb_multi.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
+                  raw_key: 'erb_multi.comment.line1'
+                }
+              ]
+            )
+        )
+
+        # Will match the same row as leaves[2] for now
+        expect_node_key_data(
+          leaves[3],
+          'erb_multi.comment.line2',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 352,
+                  line_num: 12,
+                  line_pos: 4,
+                  line: '<%= t("erb_multi.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
+                  raw_key: 'erb_multi.comment.line2'
+                }
+              ]
+            )
+        )
+
+        expect_node_key_data(
+          leaves[4],
+          'erb_multi_dash.comment.line1',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 498,
+                  line_num: 17,
+                  line_pos: 4,
+                  line: '<%= t("erb_multi_dash.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
+                  raw_key: 'erb_multi_dash.comment.line1'
+                }
+              ]
+            )
+        )
+
+        expect_node_key_data(
+          leaves[5],
+          'erb_multi_dash.comment.line2',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 498,
+                  line_num: 17,
+                  line_pos: 4,
+                  line: '<%= t("erb_multi_dash.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
+                  raw_key: 'erb_multi_dash.comment.line2'
+                }
+              ]
+            )
+        )
+
+        expect_node_key_data(
+          leaves[6],
+          'ruby_multi.comment.line1',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 642,
+                  line_num: 22,
+                  line_pos: 4,
+                  line: '<%= t("ruby_multi.comment.#{type}") %>', # rubocop:disable Lint/InterpolationCheck
+                  raw_key: 'ruby_multi.comment.line1'
+                }
+              ]
+            )
+        )
+
+        expect_node_key_data(
+          leaves[7],
+          'ruby_multi.comment.line2',
+          occurrences:
+            make_occurrences(
+              [
+                {
+                  path: 'app/views/application/comments.html.erb',
+                  pos: 588,
+                  line_num: 21,
+                  line_pos: 0,
+                  line: "# i18n-tasks-use t('ruby_multi.comment.line2') %>",
+                  raw_key: 'ruby_multi.comment.line2'
+                }
+              ]
+            )
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
- Also fixes regex in PatternScanner to handle `theme_t "foo"` being
  marked as a translation.
- Fixes #572
