### PR TITLE
Remove default translation backend

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
           strict: >-
             Avoid inferring dynamic key usages such as t("cats.#{cat}.name"). Takes precedence over
             the config setting if set.
-          translation_backend: Translation backend (google or deepl)
+          translation_backend: Translation backend [google, deepl, yandex, openai])
           value: >-
             Value. Interpolates: %%{value}, %%{human_key}, %%{key}, %%{default}, %%{value_or_human_key},
             %%{value_or_default_or_human_key}
@@ -69,11 +69,15 @@ en:
       enum_opt:
         invalid: "%{invalid} is not one of: %{valid}."
       errors:
+        invalid_backend: 'Invalid backend: %{invalid}. Must be one of %{valid}.'
         invalid_format: 'invalid format: %{invalid}. valid: %{valid}.'
         invalid_locale: 'invalid locale: %{invalid}'
         invalid_missing_type:
           one: 'invalid type: %{invalid}. valid: %{valid}.'
           other: 'unknown types: %{invalid}. valid: %{valid}.'
+        missing_backend: >-
+          No translation backend specified. Set it via the translation.backend in config/i18n-tasks.yml
+          or via the --backend option.
         pass_forest: pass locale forest
     common:
       continue_q: Continue?

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -23,7 +23,7 @@ ru:
           out_format: 'Формат вывода: %{valid_text}.'
           pattern_router: 'Использовать pattern_router: ключи распределятся по файлам согласно data.write'
           strict: Не угадывать динамические использования ключей, например `t("category.#{category.key}")`
-          translation_backend: Движок перевода (google или deepl)
+          translation_backend: Движок перевода [google, deepl, yandex, openai]
           value: >-
             Значение, интерполируется с %%{value}, %%{human_key}, %%{key}, %%{default}, %%{value_or_human_key},
             %%{value_or_default_or_human_key}
@@ -66,6 +66,7 @@ ru:
       enum_opt:
         invalid: "%{invalid} не является одним из: %{valid}."
       errors:
+        invalid_backend: 'Недопустимый источник данных: %{invalid}. Должен быть одним из %{valid}.'
         invalid_format: 'Неизвестный формат %{invalid}. Форматы: %{valid}.'
         invalid_locale: Неверный язык %{invalid}
         invalid_missing_type:
@@ -73,6 +74,9 @@ ru:
           many: 'Неизвестные типы: %{invalid}. Типы: %{valid}.'
           one: 'Неизвестный тип %{invalid}. Типы: %{valid}.'
           other: 'Неизвестные типы: %{invalid}. Типы: %{valid}.'
+        missing_backend: >-
+          Не указан источник перевода. Укажите его через translation.backend в config/i18n-tasks.yml
+          или через опцию --backend.
         pass_forest: Передайте дерево
     common:
       continue_q: Продолжить?

--- a/lib/i18n/tasks/command/option_parsers/enum.rb
+++ b/lib/i18n/tasks/command/option_parsers/enum.rb
@@ -9,13 +9,14 @@ module I18n::Tasks
             I18n.t('i18n_tasks.cmd.enum_opt.invalid', invalid: invalid, valid: valid * ', ')
           end
 
-          def initialize(valid, error_message = DEFAULT_ERROR)
+          def initialize(valid, error_message = DEFAULT_ERROR, default: true)
             @valid         = valid.map(&:to_s)
             @error_message = error_message
+            @default       = default
           end
 
           def call(value, *)
-            return @valid.first unless value.present?
+            return @valid.first if @default && value.blank?
 
             if @valid.include?(value)
               value

--- a/lib/i18n/tasks/command/options/locales.rb
+++ b/lib/i18n/tasks/command/options/locales.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'i18n/tasks/command/option_parsers/locale'
+require 'i18n/tasks/command/option_parsers/enum'
 
 module I18n::Tasks
   module Command
@@ -31,13 +32,23 @@ module I18n::Tasks
             parser: OptionParsers::Locale::Parser,
             default: 'base'
 
-        TRANSLATION_BACKENDS = %w[google deepl].freeze
+        TRANSLATION_BACKENDS = %w[google deepl yandex openai].freeze
         arg :translation_backend,
             '-b',
             '--backend BACKEND',
             t('i18n_tasks.cmd.args.desc.translation_backend'),
-            parser: OptionParsers::Locale::Parser,
-            default: TRANSLATION_BACKENDS[0]
+            parser:
+              OptionParsers::Enum::Parser.new(
+                TRANSLATION_BACKENDS,
+                proc do |value, valid|
+                  if value.present?
+                    I18n.t('i18n_tasks.cmd.errors.invalid_backend', invalid: value&.strip, valid: valid * ', ')
+                  else
+                    I18n.t('i18n_tasks.cmd.errors.missing_backend', valid: valid * ', ')
+                  end
+                end,
+                default: false
+              )
       end
     end
   end

--- a/lib/i18n/tasks/translation.rb
+++ b/lib/i18n/tasks/translation.rb
@@ -11,7 +11,7 @@ module I18n::Tasks
     # @param [String] from locale
     # @param [:deepl, :openai, :google, :yandex] backend
     # @return [I18n::Tasks::Tree::Siblings] translated forest
-    def translate_forest(forest, from:, backend: :google)
+    def translate_forest(forest, from:, backend:)
       case backend
       when :deepl
         Translators::DeeplTranslator.new(self).translate_forest(forest, from)
@@ -22,7 +22,7 @@ module I18n::Tasks
       when :yandex
         Translators::YandexTranslator.new(self).translate_forest(forest, from)
       else
-        fail CommandError, "invalid backend: #{backend}"
+        fail CommandError, backend.present? ? "invalid backend: #{backend}" : 'no backend specified'
       end
     end
   end

--- a/spec/commands/missing_commands_spec.rb
+++ b/spec/commands/missing_commands_spec.rb
@@ -47,4 +47,24 @@ RSpec.describe 'Missing commands' do
       end
     end
   end
+
+  describe '#translate_missing' do
+    it 'errors when no backend is specified' do
+      expect { run_cmd 'translate-missing' }.to(
+        raise_error(I18n::Tasks::CommandError, I18n.t('i18n_tasks.cmd.errors.missing_backend'))
+      )
+    end
+
+    it 'errors when invalid backend is specified' do
+      invalid = 'awesome-translate'
+
+      expect { run_cmd 'translate-missing', "-b #{invalid}" }.to(
+        raise_error(
+          I18n::Tasks::CommandError,
+          I18n.t('i18n_tasks.cmd.errors.invalid_backend',
+                 invalid: invalid, valid: I18n::Tasks::Command::Options::Locales::TRANSLATION_BACKENDS * ', ')
+        )
+      )
+    end
+  end
 end


### PR DESCRIPTION
Modify the Enum option parser to have an option, `default` which allows indicating if the option parser should fall back to the first valid value.

For translation backends, we do not want to have a default because the user must configure the translation backend.

Modify the translation_backend argument to provide an error message when no backend is specified