### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/i18n-tasks

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   TEXT
   s.homepage = 'https://github.com/glebm/i18n-tasks'
   s.metadata = {
+    'changelog_uri' => 'https://github.com/glebm/i18n-tasks/blob/main/CHANGES.md',
     'issue_tracker' => 'https://github.com/glebm/i18n-tasks',
     'rubygems_mfa_required' => 'true'
   }

--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -29,7 +29,8 @@ Gem::Specification.new do |s|
   s.metadata = {
     'changelog_uri' => 'https://github.com/glebm/i18n-tasks/blob/main/CHANGES.md',
     'issue_tracker' => 'https://github.com/glebm/i18n-tasks',
-    'rubygems_mfa_required' => 'true'
+    'rubygems_mfa_required' => 'true',
+    'source_code_uri' => 'https://github.com/glebm/i18n-tasks'
   }
   s.required_ruby_version = '>= 2.6', '< 4.0'
 


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/i18n-tasks which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/