### PR TITLE
update i18n tasks interpolations for deepl

### DIFF
--- a/lib/i18n/tasks/interpolations.rb
+++ b/lib/i18n/tasks/interpolations.rb
@@ -3,25 +3,30 @@
 module I18n::Tasks
   module Interpolations
     class << self
-      attr_accessor :variable_regex
+      attr_accessor :variable_regex, :tag_pairs, :tag_with_localized_value_regex
     end
-    @variable_regex = /(?<!%)%{[^}]+}/.freeze
+    @variable_regex = /(?<!%)%\{[^}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
+    @tag_pairs = [
+      ['{{', '}}'],
+      ['%{', '}'],
+      ['{%', '%}']
+    ].freeze
+    @tag_with_localized_value_regex = /\{\{\s?(("[^"]+")|('[^']+'))\s?\|.*?\}\}/
 
     def inconsistent_interpolations(locales: nil, base_locale: nil) # rubocop:disable Metrics/AbcSize
       locales ||= self.locales
       base_locale ||= self.base_locale
       result = empty_forest
-      variable_regex = I18n::Tasks::Interpolations.variable_regex
 
       data[base_locale].key_values.each do |key, value|
         next if !value.is_a?(String) || ignore_key?(key, :inconsistent_interpolations)
 
-        base_vars = Set.new(value.scan(variable_regex))
+        base_vars = get_normalized_variables_set(value)
         (locales - [base_locale]).each do |current_locale|
           node = data[current_locale].first.children[key]
           next unless node&.value.is_a?(String)
 
-          if base_vars != Set.new(node.value.scan(variable_regex))
+          if base_vars != get_normalized_variables_set(node.value)
             result.merge!(node.walk_to_root.reduce(nil) { |c, p| [p.derive(children: c)] })
           end
         end
@@ -29,6 +34,28 @@ module I18n::Tasks
 
       result.each { |root| root.data[:type] = :inconsistent_interpolations }
       result
+    end
+
+    def get_normalized_variables_set(string)
+      Set.new(string.scan(I18n::Tasks::Interpolations.variable_regex).map { |variable| normalize(variable) })
+    end
+
+    def normalize(variable)
+      normalized = nil
+      if (match = variable.match(I18n::Tasks::Interpolations.tag_with_localized_value_regex))
+        variable = variable.sub(match[1], 'localized input')
+      end
+      I18n::Tasks::Interpolations.tag_pairs.each do |start, end_|
+        next unless variable.start_with?(start)
+
+        normalized = variable.delete_prefix(start).delete_suffix(end_).strip
+        normalized = start + normalized + end_
+        break
+      end
+
+      fail 'No start/end tag pair detected' if normalized.nil?
+
+      normalized
     end
   end
 end

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -104,7 +104,7 @@ module I18n::Tasks
         end
       end
 
-      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
+      INTERPOLATION_KEY_RE = /%\{[^}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
       UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -104,7 +104,7 @@ module I18n::Tasks
         end
       end
 
-      INTERPOLATION_KEY_RE = /%\{[^}]+}/.freeze
+      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*\}\}|\{%.*%\}/.freeze
       UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -104,7 +104,7 @@ module I18n::Tasks
         end
       end
 
-      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*\}\}|\{%.*%\}/.freeze
+      INTERPOLATION_KEY_RE = /%\{[^\}]+\}|\{\{.*?\}\}|\{%.*?%\}/.freeze
       UNTRANSLATABLE_STRING = 'X__'
 
       # @param [String] value

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -23,6 +23,11 @@ module I18n::Tasks::Translators
 
     def translate_values(list, from:, to:, **options)
       results = []
+
+      if ( glossary = glossary_for(from, to) )
+        options.merge!({ glossary_id: glossary.id })
+      end
+
       list.each_slice(BATCH_SIZE) do |parts|
         res = DeepL.translate(
           parts,
@@ -91,6 +96,13 @@ module I18n::Tasks::Translators
       else
         loc.upcase
       end
+    end
+
+    # Find the largest glossary given a language pair
+    def glossary_for(source, target)
+      DeepL.glossaries.list.select do |glossary|
+        glossary.source_lang == source && glossary.target_lang == target
+      end.sort_by(&:entry_count).last
     end
 
     def configure_api_key!

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -24,7 +24,7 @@ module I18n::Tasks::Translators
     def translate_values(list, from:, to:, **options)
       results = []
 
-      if ( glossary = glossary_for(from, to) )
+      if (glossary = glossary_for(from, to))
         options.merge!({ glossary_id: glossary.id })
       end
 
@@ -102,7 +102,7 @@ module I18n::Tasks::Translators
     def glossary_for(source, target)
       DeepL.glossaries.list.select do |glossary|
         glossary.source_lang == source && glossary.target_lang == target
-      end.sort_by(&:entry_count).last
+      end.max_by(&:entry_count)
     end
 
     def configure_api_key!

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -60,17 +60,98 @@ module I18n::Tasks::Translators
 
     # @param [String] value
     # @return [String] 'hello, %{name}' => 'hello, <i18n>%{name}</i18n>'
-    def replace_interpolations(value)
+    def original_replace_interpolations(value)
       value.gsub(INTERPOLATION_KEY_RE, '<i18n>\0</i18n>')
     end
 
     # @param [String] untranslated
     # @param [String] translated
     # @return [String] 'hello, <i18n>%{name}</i18n>' => 'hello, %{name}'
-    def restore_interpolations(untranslated, translated)
+    def original_restore_interpolations(untranslated, translated)
       return translated if untranslated !~ INTERPOLATION_KEY_RE
 
       translated.gsub(%r{</?i18n>}, '')
+    rescue StandardError => e
+      raise_interpolation_error(untranslated, translated, e)
+    end
+
+    # deepl does a better job with interpolations when it doesn't have to deal
+    # with <br> tags, so we replace all of them with meaningless asterisk chains
+    BR_REGEXP = %r{(<br\s*/?>\s*)+}i.freeze
+    BR_SINGLE_MARKER = ' *** '
+    BR_DOUBLE_MARKER = ' ***** '
+
+    # letting deepl 'read' the interpolations gives better translations (and
+    # solves the problem of interpolations getting pushed all the way to the
+    # front of the sentence), however, deepl will also try to translate
+    # the interpolations and that gets messy.
+    # we use nonsense three-letter acronyms so deepl will 'read' them and leave
+    # them alone (the letter X also works very well, except in sentences with
+    # several consecutive interpolations because that reads X X X and deepl
+    # doesn't handle that well)
+    # deepl also needs to know if an interpolation will be a word or a number,
+    # for romance languages it matters. a little Spanish lesson to illustrate:
+    # "%{foo} betalingen" translates either to "facturas %{foo}"
+    # (openstaande betalingen -> facturas pendientes) or to "%{foo} facturas"
+    # (5 betalingen -> 5 facturas)
+    # for interpolation keys that are usually numeric, we pick a number
+    # instead of the three-letter acronym (more consistency in how we name
+    # interpolation keys would help)
+    LETTER_SUBS = %w[RYX QFN VLB XOG DWP ZMQ JZQ WVS LRX HPM].freeze
+    NUM_SUBS = %w[17 19 23 29 31 37 41 43 47 53].freeze
+
+    def key_substitution(stache, index)
+      case stache.gsub(/[^a-z]/, '')
+      when 'count', 'minutes', 'hours'
+        NUM_SUBS[index % NUM_SUBS.size]
+      else
+        LETTER_SUBS[index % LETTER_SUBS.size]
+      end
+    end
+
+    # BEX version of replace_interpolation
+    def replace_interpolations(value)
+      key_index = 0
+      value.gsub(INTERPOLATION_KEY_RE) do |stache|
+        sub = key_substitution(stache, key_index)
+        key_index += 1
+        "<var stache=\"#{stache}\" sub=\"#{sub}\">#{sub}</var>"
+      end.gsub(BR_REGEXP) do |br|
+        if br.downcase.count('b') == 2
+          # never more than two <br> in a row, it gets messy
+          BR_DOUBLE_MARKER
+        else
+          BR_SINGLE_MARKER
+        end
+      end
+    end
+
+    # reversing our substitutions should be straight-forward, but it's not
+    # because deepl gets creative. cases are explained inline.
+    def restore_interpolations(untranslated, translated)
+      translated.gsub(%r{(.?)<var stache="([^"]*)" sub="([^"]*)">([^<]*)</var>}) do
+        char = $1
+        stache = $2
+        sub = $3
+        body = $4
+        if body == sub
+          # deepl kept the 'sub' text inside the <var> tag and nothing else, clean.
+          "#{char}#{stache}"
+        elsif body.index(sub)
+          # deepl took some letters from outside the <var> tag and placed them
+          # inside the <var> e.g. task <var>"RYX</var>"
+          before, after = body.split(sub,2)
+          "#{before}#{stache}#{after}"
+        elsif "#{char}#{body}".downcase == sub.downcase
+          # deepl took the first letter from inside the <var> tag and placed it
+          # immediately before the <var> tag e.g. R<var>yx</var>
+          stache
+        else
+          # instead of trying to look normal the fallback prints something
+          # obviously wrong hoping to get some attention and a manual fix
+          "!!!!!#{sub.inspect} (#{char.inspect} #{body.inspect})!!!!!"
+        end
+      end.gsub(BR_DOUBLE_MARKER, '<br /><br />').gsub(BR_SINGLE_MARKER, '<br />')
     rescue StandardError => e
       raise_interpolation_error(untranslated, translated, e)
     end

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -6,8 +6,14 @@ require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
   nil_value_test  = ['nil-value-key', nil, nil]
-  text_test       = ['key', "Hello, %{user} O'Neill! How are you?", "¡Hola, %{user} O'Neill! ¿Qué tal estás?"]
-  html_test_plrl  = ['html-key.html.one', '<span>Hello %{count}</span>', '<span>Hola %{count}</span>']
+
+  text_test = [
+    'key',
+    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}",
+    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}"
+  ]
+
+  html_test_plrl = ['html-key.html.one', '<span>Hello %{count} {{ count }} {% count %}</span>', '<span>Hola %{count} {{ count }} {% count %}</span>']
   array_test      = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   array_hash_test = ['array-hash-key',
                      [{ 'hash_key1' => 'How are you?' }, { 'hash_key2' => nil }, { 'hash_key3' => 'Well.' }],

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -5,15 +5,20 @@ require 'i18n/tasks/commands'
 require 'deepl'
 
 RSpec.describe 'DeepL Translation' do
-  nil_value_test  = ['nil-value-key', nil, nil]
+  nil_value_test = ['nil-value-key', nil, nil]
 
   text_test = [
     'key',
-    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}",
-    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}"
+    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} \
+    {% That applies to this Liquid tag as well %}",
+    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} \
+    {% That applies to this Liquid tag as well %}"
   ]
 
-  html_test_plrl = ['html-key.html.one', '<span>Hello %{count} {{ count }} {% count %}</span>', '<span>Hola %{count} {{ count }} {% count %}</span>']
+  html_test_plrl = [
+    'html-key.html.one', '<span>Hello %{count} {{ count }} {% count %}</span>',
+    '<span>Hola %{count} {{ count }} {% count %}</span>'
+  ]
   array_test      = ['array-key', ['Hello.', nil, '', 'Goodbye.'], ['Hola.', nil, '', 'Adiós.']]
   array_hash_test = ['array-hash-key',
                      [{ 'hash_key1' => 'How are you?' }, { 'hash_key2' => nil }, { 'hash_key3' => 'Well.' }],

--- a/spec/deepl_translate_spec.rb
+++ b/spec/deepl_translate_spec.rb
@@ -9,10 +9,8 @@ RSpec.describe 'DeepL Translation' do
 
   text_test = [
     'key',
-    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} \
-    {% That applies to this Liquid tag as well %}",
-    "¡Hola, %{user} O'Neill! ¿Qué tal estás? {{ Check out this Liquid tag, it should not be translated }} \
-    {% That applies to this Liquid tag as well %}"
+    "Hello, %{user} O'Neill! How are you? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}",
+    "¡Hola, %{user} O'Neill! ¿Qué tal? {{ Check out this Liquid tag, it should not be translated }} {% That applies to this Liquid tag as well %}"
   ]
 
   html_test_plrl = [
@@ -90,6 +88,82 @@ RSpec.describe 'DeepL Translation' do
           ).to eq('<span>Coches</span> &lt;&lt; Camiones / %{keep_this}')
         end
       end
+    end
+  end
+
+  # Don't expect deepl's answers to be exactly the same each run
+  describe 'in het Nederlands' do
+    let(:base_task) { I18n::Tasks::BaseTask.new }
+
+    before do
+      # this is a good place to go ENV['DEEPL_AUTH_KEY'] = '...' but do not commit it
+      skip 'temporarily disabled on JRuby due to https://github.com/jruby/jruby/issues/4802' if RUBY_ENGINE == 'jruby'
+      skip 'DEEPL_AUTH_KEY env var not set' unless ENV['DEEPL_AUTH_KEY']
+    end
+
+    it 'tells time' do
+      german, english, spanish =
+        translate_dutch(hours_and_minutes: "%{hours} uur en %{minutes} minuten")
+      expect(german).to eq '%{hours} Stunden und %{minutes} Minuten'
+      expect(english).to eq '%{hours} hours and %{minutes} minutes'
+      expect(spanish).to eq '%{hours} horas y %{minutes} minutos'
+    end
+
+    it 'counts' do
+      german, english, spanish =
+        translate_dutch(other: "%{count} taken")
+      expect(german).to eq '%{count} Aufgaben'
+      expect(english).to eq '%{count} tasks'
+      expect(spanish).to eq '%{count} tareas'
+    end
+
+    it 'assigns' do
+      german, english, spanish =
+        translate_dutch(assigned: 'Taak "%{todo}" toegewezen aan %{user}')
+      expect(german).to eq 'To-dos "%{todo}" zugewiesen an %{user}'
+      expect(english).to eq 'Task "%{todo}" assigned to %{user}'
+      expect(spanish).to eq 'Tarea "%{todo}" asignada a %{user}'
+    end
+
+    it 'sings' do
+      german, english, spanish =
+        translate_dutch(verse: "Ik zou zo graag een %{animal} kopen. Ik Zag %{count} beren %{food} smeren")
+      expect(german).to eq 'Ich würde so gerne einen %{animal} kaufen. Ich sah %{count} Bären, die %{food} schmierten'
+      # greasing is a funny way to say smeren, but we let it slide
+      expect(english).to eq 'I would so love to buy a %{animal}. I saw %{count} bears greasing %{food}'
+      expect(spanish).to eq 'Me encantaría comprar un %{animal}. Vi %{count} osos engrasando %{food}'
+    end
+
+    it 'sends emails' do
+      german, english, spanish =
+        translate_dutch(email_body_html: "{{ booking.greeting }},<br><br>Bijgevoegd ziet u een factuur van {{ park.name }} met factuurnummer {{ invoice.invoice_nr }}.<br />Volgens onze administratie had het verschuldigde bedrag van {{ locals.payment_collector_total }} op {{ locals.payment_collector_deadline }} moeten zijn betaald. Helaas hebben we nog geen betaling ontvangen.<br>")
+      puts german
+      puts english
+      puts spanish
+      expect(german).to eq '{{ booking.greeting }},<br /><br />Anbei finden Sie eine Rechnung von {{ park.name }} mit der Rechnungsnummer {{ invoice.invoice_nr }}.<br />Laut unserer Verwaltung hätte der von {{ locals.payment_collector_total }} geschuldete Betrag am {{ locals.payment_collector_deadline }} bezahlt werden müssen. Leider haben wir die Zahlungen noch nicht erhalten.<br />'
+      expect(english).to eq '{{ booking.greeting }},<br /><br />Attached please find an invoice from {{ park.name }} with invoice number {{ invoice.invoice_nr }}.<br />According to our records, the amount due from {{ locals.payment_collector_total }} on {{ locals.payment_collector_deadline }} should have been paid. Unfortunately, we have not yet received payment.<br />'
+      expect(spanish).to eq '{{ booking.greeting }},<br /><br />Adjuntamos una factura de {{ park.name }} con el número de factura {{ invoice.invoice_nr }}.<br />Según nuestros registros, el importe adeudado por {{ locals.payment_collector_total }} debería haber sido abonado en {{ locals.payment_collector_deadline }}. Lamentablemente, aún no hemos recibido el pago.<br />'
+    end
+
+    it 'asks itself why are you even translating this' do
+      german, english, spanish =
+        translate_dutch(action: '%{subject} %{verb} %{object}')
+      expect(german).to eq '%{subject} %{verb} %{object}'
+      expect(english).to eq '%{subject} %{verb} %{object}'
+      expect(spanish).to eq '%{subject} %{verb} %{object}'
+    end
+
+    def translate_dutch(dutch_pair)
+      key = dutch_pair.keys.first
+      phrase = dutch_pair[key]
+      locales = %w[de en-us es]
+      branches = locales.inject({}) do |hash, locale|
+        hash[locale] = { 'testing' => { key => phrase } }
+        hash
+      end
+      tree = build_tree(branches)
+      translations = base_task.translate_forest(tree, from: 'nl', backend: :deepl)
+      locales.map { |locale| translations[locale]['testing'][key].value.strip }
     end
   end
 end

--- a/spec/interpolations_spec.rb
+++ b/spec/interpolations_spec.rb
@@ -25,13 +25,63 @@ RSpec.describe 'Interpolations' do
     TestCodebase.teardown
   end
 
-  it '#inconsistent_interpolation' do
-    wrong  = task.inconsistent_interpolations
-    leaves = wrong.leaves.to_a
+  context 'ruby string interpolations' do
+    let(:base_keys) { { 'a' => 'hello %{world}', 'b' => 'foo', 'c' => { 'd' => 'hello %{name}' }, 'e' => 'ok' } }
+    let(:test_keys) { { 'a' => 'hello', 'b' => 'foo %{bar}', 'c' => { 'd' => 'hola %{amigo}' }, 'e' => 'ok' } }
 
-    expect(leaves.size).to eq 3
-    expect(leaves[0].full_key).to eq 'es.a'
-    expect(leaves[1].full_key).to eq 'es.b'
-    expect(leaves[2].full_key).to eq 'es.c.d'
+    it 'detects inconsistent interpolations' do
+      wrong  = task.inconsistent_interpolations
+      leaves = wrong.leaves.to_a
+
+      expect(leaves.size).to eq 3
+      expect(leaves[0].full_key).to eq 'es.a'
+      expect(leaves[1].full_key).to eq 'es.b'
+      expect(leaves[2].full_key).to eq 'es.c.d'
+    end
+  end
+
+  context 'liquid tags' do
+    let(:base_keys) do
+      {
+        a: 'hello {{ world }}',
+        b: 'foo',
+        c: {
+          d: 'hello {{ name }}'
+        },
+        e: 'ok',
+        f: 'inconsistent {{ whitespace}}',
+        g: 'includes a {% comment %}',
+        h: 'wrong {% comment %}',
+        i: 'with localized value: {{ "thanks" | owner_invoice }}',
+        j: 'with wrong function: {{ "thanks" | owner_invoices }}'
+      }
+    end
+    let(:test_keys) do
+      {
+        a: 'hello',
+        b: 'foo {{ bar }}',
+        c: {
+          d: 'hola {{ amigo }}'
+        },
+        e: 'ok',
+        f: '{{whitespace }} inconsistentes',
+        g: 'incluye un {% comment %}',
+        h: '{% commentario %} equivocado',
+        i: 'con valor localizado: {{ "gracias" | owner_invoice }}',
+        j: 'con función incorrecta: {{ "thanks" | owner_invoice }}'
+      }
+    end
+
+    it 'detects inconsistent interpolations' do
+      wrong  = task.inconsistent_interpolations
+      leaves = wrong.leaves.to_a
+
+      expect(leaves.size).to eq 5
+      expect(leaves[0].full_key).to eq 'es.a'
+      expect(leaves[1].full_key).to eq 'es.b'
+      expect(leaves[2].full_key).to eq 'es.c.d'
+      expect(leaves[3].full_key).to eq 'es.h'
+      expect(leaves[4].full_key).to eq 'es.j'
+    end
   end
 end

--- a/spec/interpolations_spec.rb
+++ b/spec/interpolations_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Interpolations' do
     TestCodebase.teardown
   end
 
-  context 'ruby string interpolations' do
+  context 'when using ruby string interpolations' do
     let(:base_keys) { { 'a' => 'hello %{world}', 'b' => 'foo', 'c' => { 'd' => 'hello %{name}' }, 'e' => 'ok' } }
     let(:test_keys) { { 'a' => 'hello', 'b' => 'foo %{bar}', 'c' => { 'd' => 'hola %{amigo}' }, 'e' => 'ok' } }
 
@@ -40,7 +40,7 @@ RSpec.describe 'Interpolations' do
     end
   end
 
-  context 'liquid tags' do
+  context 'when using liquid tags' do
     let(:base_keys) do
       {
         a: 'hello {{ world }}',


### PR DESCRIPTION
i18n-tasks normally send DeepL something like:
Taak "<i18n>%{todo}</i18n>" toegewezen aan <i18n>%{user}</i18n>
and gets back
<i18n>%{todo}</i18n>To-dos " " zugewiesen an <i18n>%{user}</i18n>
That mess is the reason why this PR is needed

In this PR we send a custom <var> tag like:
Taak "<var stache="%{todo}" sub="RYX">RYX</var>" toegewezen aan <var stache="%{user}" sub="QFN">QFN</var>
and get back
To-dos "<var stache="%{todo}" sub="RYX">RYX</var>" zugewiesen an <var stache="%{user}" sub="QFN">QFN</var>

XML attributes aren't modified by DeepL, so we can rely on stache (short for moustache) to come back with the original interpolation key, and sub to come back with the text we substituted for the interpolation key.

Now we can allow DeepL to "read" the <var> tags (whereas <i18n> were ignored), and that makes for better translations, and solves the problem of interpolations getting pushed to the front.

What we get back isn't all sunshine and rainbows, though, DeepL will still occasionally mangle it. More details in the code.
