### PR TITLE
Identify and translate missing plural keys

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,7 @@ en:
           nostdin: Do not read from stdin
           out_format: 'Output format: %{valid_text}'
           pattern_router: 'Use pattern router: keys moved per config data.write'
+          skip_interpolation: Skip translating strings that are straight interpolations (eg. "%{comment}")
           strict: >-
             Avoid inferring dynamic key usages such as t("cats.#{cat}.name"). Takes precedence over
             the config setting if set.
@@ -112,6 +113,7 @@ en:
     missing:
       details_title: Value in other locales or source
       none: No translations are missing.
+      plural: Missing plural keys
     openai_translate:
       errors:
         no_api_key: >-

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -22,6 +22,8 @@ ru:
           nostdin: Не читать дерево из стандартного ввода
           out_format: 'Формат вывода: %{valid_text}.'
           pattern_router: 'Использовать pattern_router: ключи распределятся по файлам согласно data.write'
+          skip_interpolation: Пропустить перевод строк, которые являются прямыми интерполяциями (например,
+            "%{comment}")
           strict: Не угадывать динамические использования ключей, например `t("category.#{category.key}")`
           translation_backend: Движок перевода [google, deepl, yandex, openai]
           value: >-
@@ -111,6 +113,7 @@ ru:
     missing:
       details_title: На других языках или в коде
       none: Всё переведено.
+      plural: Отсутствуют ключи множественного числа
     openai_translate:
       errors:
         no_api_key: |-

--- a/lib/i18n/tasks/command/commands/missing.rb
+++ b/lib/i18n/tasks/command/commands/missing.rb
@@ -40,10 +40,10 @@ module I18n::Tasks
         cmd :translate_missing,
             pos: '[locale ...]',
             desc: t('i18n_tasks.cmd.desc.translate_missing'),
-            args: [:locales, :locale_to_translate_from, arg(:out_format).from(1), :translation_backend, :pattern]
+            args: [:locales, :locale_to_translate_from, arg(:out_format).from(1), :translation_backend, :pattern, :skip_interpolation]
 
         def translate_missing(opt = {})
-          missing = i18n.missing_diff_forest opt[:locales], opt[:from]
+          missing = i18n.missing_diff_forest opt[:locales], opt[:from], opt[:skip_interpolation] != 'false'
           if opt[:pattern]
             pattern_re = i18n.compile_key_pattern(opt[:pattern])
             missing.select_keys! { |full_key, _node| full_key =~ pattern_re }

--- a/lib/i18n/tasks/command/options/common.rb
+++ b/lib/i18n/tasks/command/options/common.rb
@@ -33,6 +33,11 @@ module I18n::Tasks
             '--config FILE',
             t('i18n_tasks.cmd.args.desc.config')
 
+        arg :skip_interpolation,
+            '-s',
+            '--skip_interpolation',
+            t('i18n_tasks.cmd.args.desc.skip_interpolation')
+
         def arg_or_pos!(key, opts)
           opts[key] ||= opts[:arguments].try(:shift)
         end

--- a/lib/i18n/tasks/reports/terminal.rb
+++ b/lib/i18n/tasks/reports/terminal.rb
@@ -116,7 +116,8 @@ module I18n
           when :missing_used
             first_occurrence leaf
           when :missing_plural
-            leaf[:data][:missing_keys].join(', ')
+            "#{Rainbow(I18n.t('i18n_tasks.missing.plural')).cyan} " +
+              leaf[:data][:missing_keys].join(', ')
           else
             "#{Rainbow(leaf[:data][:missing_diff_locale]).cyan} " \
             "#{format_value(leaf[:value].is_a?(String) ? leaf[:value].strip : leaf[:value])}"

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -13,6 +13,8 @@ module I18n::Tasks
       # @param [String] from locale
       # @return [I18n::Tasks::Tree::Siblings] translated forest
       def translate_forest(forest, from)
+        merge_missing_plural_nodes!(forest)
+
         forest.inject @i18n_tasks.empty_forest do |result, root|
           translated = translate_pairs(root.key_values(root: true), to: root.key, from: from)
           result.merge! Data::Tree::Siblings.from_flat_pairs(translated)
@@ -20,6 +22,34 @@ module I18n::Tasks
       end
 
       protected
+
+      # Recursively loop through the tree until all :missing_plural nodes have
+      # been added to the base
+      # @param [I18n::Tasks::Data::Tree::Node] node
+      # @return [void]
+      def merge_missing_plural_nodes!(node)
+        return unless node.children?
+
+        node.children.each do |child|
+          if child.data[:type] == :missing_plural
+            child.data.delete(:type)
+            child.data.delete(:missing_keys).each do |missing_key|
+              # If the key is present use it, otherwise use the 'other' value
+              other_value = child.value[missing_key.to_s] || child.value['other']
+
+              new_node = Data::Tree::Node.new(
+                key: missing_key,
+                value: other_value,
+                parent: child.parent,
+                data: { type: :missing_plural_key, locale: node }
+              )
+              child.append!(new_node)
+            end
+          else
+            merge_missing_plural_nodes!(child)
+          end
+        end
+      end
 
       # @param [Array<[String, Object]>] list of key-value pairs
       # @return [Array<[String, Object]>] translated list
@@ -32,6 +62,7 @@ module I18n::Tasks
         reference_key_vals = list.select { |_k, v| v.is_a? Symbol } || []
         list -= reference_key_vals
         result = list.group_by { |k_v| @i18n_tasks.html_key? k_v[0], opts[:from] }.map do |is_html, list_slice|
+
           fetch_translations(list_slice, opts.merge(is_html ? options_for_html : options_for_plain))
         end.reduce(:+) || []
         result.concat(reference_key_vals)
@@ -51,7 +82,7 @@ module I18n::Tasks
       # @param [Array<[String, Object]>] list of key-value pairs
       # @return [Array<String>] values for translation extracted from list
       def to_values(list, opts)
-        list.map { |l| dump_value(l[1], opts) }.flatten.compact
+        list.map { |l| dump_value(l[1], opts) }.compact
       end
 
       # @param [Array<[String, Object]>] list
@@ -102,6 +133,10 @@ module I18n::Tasks
         else
           untranslated
         end
+      rescue StopIteration => e
+        require 'pry'
+        binding.pry
+        raise e
       end
 
       INTERPOLATION_KEY_RE = /%\{[^}]+}/.freeze

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -16,6 +16,12 @@ module I18n::Tasks::Translators
 
       HTML markups (enclosed in < and > characters) must not be changed under any circumstance.
       Variables (starting with %%{ and ending with }) must not be changed under any circumstance.
+      Any provided keys must not be changed under any circumstance.
+
+      If a "%{count}" interpolation is given for the "other" plural key, you should try and use
+      that in the translation for any missing pluralizations keys that may represent multiples.
+      The goal is to conform to the Unicode CLDR plural rules while maintaining a understandable
+      translation.
 
       Keep in mind the context of all the strings for a more accurate translation.
     PROMPT
@@ -76,11 +82,16 @@ module I18n::Tasks::Translators
 
       list.each_slice(BATCH_SIZE) do |batch|
         translations = translate(batch, from, to)
+        result = JSON.parse(remove_json_markdown(translations))
 
-        results << JSON.parse(translations)
+        results << result
       end
 
       results.flatten
+    end
+
+    def remove_json_markdown(string)
+      string.gsub(/^```json\s*(.*?)\s*```$/m, '\1').strip
     end
 
     def translate(values, from, to)

--- a/spec/plural_keys_spec.rb
+++ b/spec/plural_keys_spec.rb
@@ -78,5 +78,16 @@ RSpec.describe 'Plural keys' do
       expect(leaves[1].full_key).to eq 'ar.nested.plural_key'
       expect(leaves[1].data[:missing_keys]).to eq %i[two few many]
     end
+
+    it 'returns ignores keys with a single string' do
+      tree = build_tree(ru: { plural_key: '%{count}' })
+      task.data['ru'].merge!(tree)
+      wrong  = task.missing_plural_forest(%w[en ru])
+      leaves = wrong.leaves.to_a
+
+      expect(leaves.size).to eq 1
+      expect(leaves[0].full_key).to eq 'ru.nested.plural_key'
+      expect(leaves[0].data[:missing_keys]).to eq %i[one few many other]
+    end
   end
 end

--- a/spec/translator_spec.rb
+++ b/spec/translator_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'Translation' do
+  module I18n::Tasks::BaseTask::TranslationTestExtension
+    def translate_forest(forest, from:, backend:)
+      case backend
+      when :test
+        I18n::Tasks::Translators::TestTranslator.new(self).translate_forest(forest, from)
+      else
+        super
+      end
+    end
+  end
+  I18n::Tasks::BaseTask.prepend I18n::Tasks::BaseTask::TranslationTestExtension
+
+  module I18n::Tasks::Translators
+    class TestTranslator < BaseTranslator
+      private
+
+      def translate_values(list, from:, to:, **options)
+        list.map { |v| "translated:#{v}" }
+      end
+
+      def options_for_html
+        {}
+      end
+
+      def options_for_plain
+        {}
+      end
+
+      def options_for_translate_values(options)
+        options
+      end
+    end
+  end
+
+  let(:task) { I18n::Tasks::BaseTask.new }
+  let(:base_keys) do
+    {
+      regular_key: 'a',
+
+      plural_key: {
+        one: 'one',
+        other: '%{count}'
+      },
+
+      not_really_plural: {
+        one: 'a',
+        green: 'b'
+      },
+
+      nested: {
+        plural_key: {
+          zero: 'none',
+          one: 'one',
+          other: '%{count}'
+        }
+      },
+
+      ignored_pattern: {
+        plural_key: {
+          other: '%{count}'
+        }
+      }
+    }
+  end
+
+  around do |ex|
+    TestCodebase.setup(
+      'config/i18n-tasks.yml' => {
+        base_locale: 'en',
+        locales: %w[en ru],
+        translation_backend: :test,
+        ignore_missing: ['ignored_pattern.*']
+      }.to_yaml,
+      'config/locales/en.yml' => { en: base_keys }.to_yaml,
+      'config/locales/ru.yml' => { ru: base_keys.except(:plural_key).deep_merge({ nested: { plural_key: { many: 'existing' } } }) }.to_yaml
+    )
+    TestCodebase.in_test_app_dir { ex.call }
+    TestCodebase.teardown
+  end
+
+  describe '#missing' do
+    let(:ru_hash) do
+      {
+        'ru' => {
+          'plural_key' => {
+            'one' => 'translated:one',
+            'few' => 'translated:%{count}',
+            'many' => 'translated:%{count}',
+            'other' => 'translated:%{count}'
+          },
+          'nested' => {
+            'plural_key' => {
+              'few' => 'translated:%{count}'
+            }
+          }
+        }
+      }
+    end
+
+    it 'translates missing plural keys' do
+      missing = task.missing_plural_forest(['ru'], 'en')
+      result = task.translate_forest(missing, from: 'en', backend: :test)
+
+      expect(result.to_hash).to eq(ru_hash)
+    end
+  end
+
+  describe 'multi-line' do
+
+  end
+end


### PR DESCRIPTION
From https://github.com/glebm/i18n-tasks/issues/582

* For locales identified in a call to `translate` commands, determines the existing and required pluralization keys and adds the nodes to the forest before translating. It will additionally remove unrequired plural translation keys. 
* Adds a label to the front of missing plural keys when running the `missing` command as the table headers were a little unclear.
* Add a --skip-interpolation option to the `missing` command (but specifically intended for translation) that won't send **only** interpolated strings to translate, the reasoning behind this was a) I found OpenAI would end up getting a mismatched number of results returned if there were a lot of them and b) it's kind of wasteful as a correctly configured Rails implementation would fallback and work correctly.

I think there's still some cleanup to do here, it feels a little clobbered together as I was learning as I went so totally happy to solicit feedback (or hear and attempt to address any problems).