### PR TITLE
RailsModelMatcher: Handles calls without model

### DIFF
--- a/lib/i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb
@@ -16,7 +16,7 @@ module I18n::Tasks::Scanners::AstMatchers
       receiver = children[0]
       method_name = children[1]
 
-      return unless method_name == :human_attribute_name && receiver.type == :const
+      return unless method_name == :human_attribute_name && receiver&.type == :const
 
       value = children[2]
 

--- a/spec/fixtures/used_keys/a.rb
+++ b/spec/fixtures/used_keys/a.rb
@@ -14,6 +14,9 @@ class A
     translate('activerecord.attributes.absolute.attribute')
     Archive.human_attribute_name(:name)
     User.model_name.human(count: 2)
+    # Cannot infer the type
+    human_attribute_name(:name)
+    model_name.human(count: 2)
   end
 
   SCOPE_CONSTANT = 'path.in.translation.file'.freeze


### PR DESCRIPTION
- `human_attribute_name` would cause errors
- Fixes #489
