### PR TITLE
Allow spaces in locale key

### DIFF
--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = %r{(?:[[:word:]]|[-.?!:;À-ž/])}.freeze
+    VALID_KEY_CHARS = %r{(?:[[:word:]]|[-.?!:;À-ž/]|(?<=\w)\s(?=\w))}.freeze
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/.freeze
 
     def valid_key?(key)

--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = %r{(?:[[:word:]]|[-.?!:;À-ž/]|(?<=[\p{L}\d])\s(?=[\p{L}\d]))}.freeze
+    VALID_KEY_CHARS = %r{(?:[[:word:]]|[-.?!:;À-ž\\/]|(?<=[\p{L}\d])\s(?=[\p{L}\d]))}.freeze
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/.freeze
 
     def valid_key?(key)

--- a/lib/i18n/tasks/scanners/ruby_key_literals.rb
+++ b/lib/i18n/tasks/scanners/ruby_key_literals.rb
@@ -20,7 +20,7 @@ module I18n::Tasks::Scanners
       literal
     end
 
-    VALID_KEY_CHARS = %r{(?:[[:word:]]|[-.?!:;À-ž/]|(?<=\w)\s(?=\w))}.freeze
+    VALID_KEY_CHARS = %r{(?:[[:word:]]|[-.?!:;À-ž/]|(?<=[\p{L}\d])\s(?=[\p{L}\d]))}.freeze
     VALID_KEY_RE    = /^#{VALID_KEY_CHARS}+$/.freeze
 
     def valid_key?(key)

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe 'RubyKeyLiterals' do
     it 'allows forward slash in key' do
       expect(scanner).to be_valid_key('category/product')
     end
-  end
 
-  describe '#valid_key?' do
     it 'allows spaces in key' do
       expect(scanner).to be_valid_key('key with spaces')
     end

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -13,4 +13,10 @@ RSpec.describe 'RubyKeyLiterals' do
       expect(scanner).to be_valid_key('category/product')
     end
   end
+
+  describe '#valid_key?' do
+    it 'allows spaces in key' do
+      expect(scanner).to be_valid_key('key with spaces')
+    end
+  end
 end

--- a/spec/scanners/ruby_key_literals_spec.rb
+++ b/spec/scanners/ruby_key_literals_spec.rb
@@ -13,8 +13,32 @@ RSpec.describe 'RubyKeyLiterals' do
       expect(scanner).to be_valid_key('category/product')
     end
 
-    it 'allows spaces in key' do
-      expect(scanner).to be_valid_key('key with spaces')
+    context 'with spaces in key' do
+      it 'allows plain string' do
+        expect(scanner).to be_valid_key('key with spaces')
+      end
+
+      it 'allows Unicode characters' do
+        expect(scanner).to be_valid_key('привет мир 你好 世界')
+      end
+
+      it 'allows mixed ASCII and Unicode' do
+        expect(scanner).to be_valid_key('product カテゴリー with スペース')
+      end
+
+      it 'allows numbers and Unicode' do
+        expect(scanner).to be_valid_key('項目123 テスト 456')
+      end
+    end
+
+    context 'with various writing systems' do
+      it 'allows right-to-left text' do
+        expect(scanner).to be_valid_key('مرحبا بالعالم')
+      end
+
+      it 'allows mixed direction text' do
+        expect(scanner).to be_valid_key('Hello مرحبا 世界')
+      end
     end
   end
 end


### PR DESCRIPTION
This update allows spaces in translation keys.

Previously, keys containing spaces (e.g., "Key with Spaces") were not considered valid and were removed from the results after scanning the file. With this change, translation keys with spaces are now recognized as valid.

Closes https://github.com/glebm/i18n-tasks/issues/359