### PR TITLE
Allow aliases for deepl locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ GOOGLE_TRANSLATE_API_KEY=<Google Translate API key>
 <a name="deepl-translation-config"></a>
 ### DeepL Pro Translate
 
-`i18n-tasks translate-missing` requires a DeepL Pro API key, get it at [DeepL](https://www.deepl.com/pro).
+`i18n-tasks translate-missing` requires a DeepL Pro API key, get it at [DeepL](https://www.deepl.com/pro). You can specify alias locales if you only use the simple locales internally.
 
 ```yaml
 # config/i18n-tasks.yml
@@ -436,6 +436,9 @@ translation:
     - 2c6415be-1852-4f54-9e1b-d800463496b4
   deepl_options:
     formality: prefer_less
+  deepl_locale_aliases:
+    en: en-us
+    pt: pt-br
 ```
 
 or via environment variables:

--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -85,6 +85,9 @@ module I18n::Tasks::Translators
 
     # Convert 'es-ES' to 'ES' but warn about locales requiring a specific variant
     def to_deepl_target_locale(locale)
+      locale_aliases = @i18n_tasks.translation_config[:deepl_locale_aliases]
+      locale = locale_aliases[locale.to_s.downcase] || locale if locale_aliases.is_a?(Hash)
+
       loc, sub = locale.to_s.split('-')
       if SPECIFIC_TARGETS.include?(loc)
         # Must see how the deepl api evolves, so this could be an error in the future


### PR DESCRIPTION
If you only use the short locale name internally, you can use this commit in deepl to force a specific variant of the locale.

In my project, all existing translations are marked as “pt”. However, the automatic translations should be done with “pt-br”. This feature is therefore required.