### PR TITLE
OpenAI: log errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Implement ENV["OPENAI_LOG_ERRORS"] to display OpenAI http log_errors [#614](https://github.com/glebm/i18n-tasks/pull/614) 
+* Set `log_errors` on OpenAI::Client options to true in development only to display HTTP errors from the OpenAI HTTP client. [#614](https://github.com/glebm/i18n-tasks/pull/614) 
 * Uses AST-parser for all ERB-files, not just `.html.erb`
 * [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
 * Adds contextual parser to support more Rails-translations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Set `log_errors` on OpenAI::Client options to true in development only to display HTTP errors from the OpenAI HTTP client. [#614](https://github.com/glebm/i18n-tasks/pull/614) 
+* Set `log_errors: true` on OpenAI::Client options in order to display HTTP client errors. [#614](https://github.com/glebm/i18n-tasks/pull/614) 
 * Uses AST-parser for all ERB-files, not just `.html.erb`
 * [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
 * Adds contextual parser to support more Rails-translations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Implement ENV["OPENAI_LOG_ERRORS"] to display OpenAI http log_errors [#614](https://github.com/glebm/i18n-tasks/pull/614) 
 * Uses AST-parser for all ERB-files, not just `.html.erb`
 * [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
 * Adds contextual parser to support more Rails-translations

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -70,7 +70,6 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
       conf[:deepl_version] = ENV['DEEPL_VERSION'] if ENV.key?('DEEPL_VERSION')
       conf[:openai_api_key] = ENV['OPENAI_API_KEY'] if ENV.key?('OPENAI_API_KEY')
       conf[:openai_model] = ENV['OPENAI_MODEL'] if ENV.key?('OPENAI_MODEL')
-      conf[:openai_log_errors] = ENV['OPENAI_LOG_ERRORS'] if ENV.key?('OPENAI_LOG_ERRORS')
       conf[:watsonx_api_key] = ENV['WATSONX_API_KEY'] if ENV.key?('WATSONX_API_KEY')
       conf[:watsonx_project_id] = ENV['WATSONX_PROJECT_ID'] if ENV.key?('WATSONX_PROJECT_ID')
       conf[:watsonx_model] = ENV['WATSONX_MODEL'] if ENV.key?('WATSONX_MODEL')

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -70,6 +70,7 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
       conf[:deepl_version] = ENV['DEEPL_VERSION'] if ENV.key?('DEEPL_VERSION')
       conf[:openai_api_key] = ENV['OPENAI_API_KEY'] if ENV.key?('OPENAI_API_KEY')
       conf[:openai_model] = ENV['OPENAI_MODEL'] if ENV.key?('OPENAI_MODEL')
+      conf[:openai_log_errors] = ENV['OPENAI_LOG_ERRORS'] if ENV.key?('OPENAI_LOG_ERRORS')
       conf[:watsonx_api_key] = ENV['WATSONX_API_KEY'] if ENV.key?('WATSONX_API_KEY')
       conf[:watsonx_project_id] = ENV['WATSONX_PROJECT_ID'] if ENV.key?('WATSONX_PROJECT_ID')
       conf[:watsonx_model] = ENV['WATSONX_MODEL'] if ENV.key?('WATSONX_MODEL')

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -52,7 +52,14 @@ module I18n::Tasks::Translators
     private
 
     def translator
-      @translator ||= OpenAI::Client.new(access_token: api_key)
+      @translator ||=
+        if @i18n_tasks.translation_config[:openai_log_errors]
+          OpenAI::Client.new(access_token: api_key, log_errors: @i18n_tasks.translation_config[:openai_log_errors]) do |f|
+            f.response :logger, Logger.new($stdout), bodies: true
+          end
+        else
+          OpenAI::Client.new(access_token: api_key)
+        end
     end
 
     def api_key

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -52,14 +52,12 @@ module I18n::Tasks::Translators
     private
 
     def translator
-      @translator ||=
-        if @i18n_tasks.translation_config[:openai_log_errors]
-          OpenAI::Client.new(access_token: api_key, log_errors: @i18n_tasks.translation_config[:openai_log_errors]) do |f|
-            f.response :logger, Logger.new($stdout), bodies: true
-          end
-        else
-          OpenAI::Client.new(access_token: api_key)
-        end
+      @translator ||= OpenAI::Client.new(
+        access_token: api_key,
+        # Highly recommended in development, so you can see what errors OpenAI is returning.
+        # Not recommended in production because it could leak private data to your logs.
+        log_errors: ENV.fetch('RAILS_ENV', ENV.fetch('RACK_ENV', '')) == 'development'
+      )
     end
 
     def api_key

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -52,12 +52,7 @@ module I18n::Tasks::Translators
     private
 
     def translator
-      @translator ||= OpenAI::Client.new(
-        access_token: api_key,
-        # Highly recommended in development, so you can see what errors OpenAI is returning.
-        # Not recommended in production because it could leak private data to your logs.
-        log_errors: ENV.fetch('RAILS_ENV', ENV.fetch('RACK_ENV', '')) == 'development'
-      )
+      @translator ||= OpenAI::Client.new(access_token: api_key, log_errors: true)
     end
 
     def api_key


### PR DESCRIPTION
```
bundle exec i18n-tasks translate-missing --backend=openai 
bundler: failed to load command: i18n-tasks (/Users/dev/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bin/i18n-tasks)                                                                                                                           >  ETA: ??:??:?? 0/161 (0%)
/Users/dev/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/gems/faraday-2.12.2/lib/faraday/response/raise_error.rb:30:in 'Faraday::Response::RaiseError#on_complete': the server responded with status 400 (Faraday::BadRequestError)
```

In order to have more detailed informations you can pass now OPENAI_LOG_ERRORS as environment variable to display more informations.