### PR TITLE
Append JSON instructions to OpenAI system prompt

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Append JSON instructions to OpenAI system prompt to be able to use response_format json_object
 * Uses AST-parser for all ERB-files, not just `.html.erb`
 * [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
 * Adds contextual parser to support more Rails-translations

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* Append JSON instructions to OpenAI system prompt to be able to use response_format json_object
+* Append JSON instructions to OpenAI system prompt to be able to use response_format json_object [#615](https://github.com/glebm/i18n-tasks/pull/615)
 * Uses AST-parser for all ERB-files, not just `.html.erb`
 * [Fixed regex in `PatternScanner`] (https://github.com/glebm/i18n-tasks/issues/572)
 * Adds contextual parser to support more Rails-translations

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -20,6 +20,7 @@ module I18n::Tasks::Translators
       Keep in mind the context of all the strings for a more accurate translation.
       It is CRITICAL you output only the result, without any additional information, code block syntax or comments.
     PROMPT
+    JSON_FORMAT_INSTRUCTIONS_SYSTEM_PROMPT = "Return the translations as a JSON object with a 'translations' array containing the translated strings."
 
     def initialize(*)
       begin
@@ -69,7 +70,9 @@ module I18n::Tasks::Translators
     end
 
     def system_prompt
-      @system_prompt ||= @i18n_tasks.translation_config[:openai_system_prompt].presence || DEFAULT_SYSTEM_PROMPT
+      @system_prompt ||= 
+        (@i18n_tasks.translation_config[:openai_system_prompt].presence || DEFAULT_SYSTEM_PROMPT)
+        .concat("\n#{JSON_FORMAT_INSTRUCTIONS_SYSTEM_PROMPT}")
     end
 
     def translate_values(list, from:, to:)

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -20,7 +20,9 @@ module I18n::Tasks::Translators
       Keep in mind the context of all the strings for a more accurate translation.
       It is CRITICAL you output only the result, without any additional information, code block syntax or comments.
     PROMPT
-    JSON_FORMAT_INSTRUCTIONS_SYSTEM_PROMPT = "Return the translations as a JSON object with a 'translations' array containing the translated strings."
+    JSON_FORMAT_INSTRUCTIONS_SYSTEM_PROMPT = <<~PROMPT.squish
+      Return the translations as a JSON object with a 'translations' array containing the translated strings.
+    PROMPT
 
     def initialize(*)
       begin
@@ -70,9 +72,10 @@ module I18n::Tasks::Translators
     end
 
     def system_prompt
-      @system_prompt ||= 
+      @system_prompt ||=
         (@i18n_tasks.translation_config[:openai_system_prompt].presence || DEFAULT_SYSTEM_PROMPT)
         .concat("\n#{JSON_FORMAT_INSTRUCTIONS_SYSTEM_PROMPT}")
+      @system_prompt
     end
 
     def translate_values(list, from:, to:)


### PR DESCRIPTION
In order to fix response_format json_object introduced in the following commit: https://github.com/glebm/i18n-tasks/commit/a0e2fef0b850990490e96facdfff9cb5b394f78f

```
INFO -- : response: {
  "error": {
    "message": "'messages' must contain the word 'json' in some form, to use 'response_format' of type 'json_object'.",
    "type": "invalid_request_error",
    "param": "messages",
    "code": null
  }
}
```