### PR TITLE
PrismScanner: Support more node types

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/rails_visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/rails_visitor.rb
@@ -24,9 +24,9 @@ module I18n::Tasks::Scanners::PrismScanners
 
       node
         .body
-        .body
-        .map { |n| visit(n) }
-        .each { |child_node| class_object.add_child_node(child_node) }
+        &.body
+        &.map { |n| visit(n) }
+        &.each { |child_node| class_object.add_child_node(child_node) }
 
       class_object
     end
@@ -71,6 +71,16 @@ module I18n::Tasks::Scanners::PrismScanners
 
     def handle_before_action(node) # rubocop:disable Metrics/MethodLength
       array_arguments, keywords = process_arguments(node)
+
+      if array_arguments.empty? && node.block.present?
+        return BeforeActionNode.new(
+          node: node,
+          calls: visit(node.block).calls,
+          only: keywords['only'],
+          except: keywords['except']
+        )
+      end
+
       if array_arguments.empty? || array_arguments.size > 2
         fail(
           ArgumentError,
@@ -86,10 +96,10 @@ module I18n::Tasks::Scanners::PrismScanners
           only: keywords['only'],
           except: keywords['except']
         )
-      elsif first_argument.is_a?(Prism::StatementsNode)
+      elsif first_argument.is_a?(LambdaNode)
         BeforeActionNode.new(
           node: node,
-          translation_nodes: visit(first_argument),
+          calls: first_argument.calls,
           only: keywords['only'],
           except: keywords['except']
         )


### PR DESCRIPTION
- There are lots of nodes used in e.g. Rails controllers that needs handling
- Fixes scanning for translations in before_actions with blocks and lambdas
