### PR TITLE
Set default GPT model to gpt-4o-mini

### DIFF
--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -68,7 +68,7 @@ module I18n::Tasks::Translators
     end
 
     def model
-      @model ||= @i18n_tasks.translation_config[:openai_model].presence || 'gpt-3.5-turbo'
+      @model ||= @i18n_tasks.translation_config[:openai_model].presence || 'gpt-4o-mini'
     end
 
     def system_prompt

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -122,7 +122,7 @@ search:
 #     formality: prefer_less
 #   # OpenAI
 #   openai_api_key: "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-#   # openai_model: "gpt-3.5-turbo" # see https://platform.openai.com/docs/models
+#   # openai_model: "gpt-4o-mini" # see https://platform.openai.com/docs/models
 #   # may contain `%{from}` and `%{to}`, which will be replaced by source and target locale codes, respectively (using `Kernel.format`)
 #   # openai_system_prompt: >-
 #   #   You are a professional translator that translates content from the %{from} locale


### PR DESCRIPTION
- Faster responses, larger context window
- Cheaper
- More intelligent