### PR TITLE
Prism: Avoid checking calls with receiver

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
@@ -231,6 +231,8 @@ module I18n::Tasks::Scanners::PrismScanners
 
       @methods.each do |method|
         method.calls.each do |call|
+          next if call.receiver.present?
+
           other_method = methods_by_name[call.name]&.first || private_methods_by_name[call.name]&.first
           next unless other_method
 

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe 'PrismScanner' do
         ).to be_empty
       end
 
+      it 'handles call with same name' do
+        source = <<~RUBY
+          class EventsController < ApplicationController
+            def new
+              @user = User.new
+            end
+          end
+        RUBY
+
+        expect(
+          process_string('app/controllers/events_controller.rb', source)
+        ).to be_empty
+      end
+
       it 'handles more syntax' do
         occurrences =
           process_path('./spec/fixtures/prism_controller.rb')


### PR DESCRIPTION
This controller method triggered the cyclic check, but it shouldn't have
```ruby
def new
  @user = User.new
end
```
