### PR TITLE
Prism: Handles more arguments

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/arguments_visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/arguments_visitor.rb
@@ -9,9 +9,16 @@ module I18n::Tasks::Scanners::PrismScanners
   class ArgumentsVisitor < Prism::Visitor
     def visit_keyword_hash_node(node)
       node.child_nodes.each_with_object({}) do |child, hash|
+        next if child.type == :assoc_splat_node
+
         hash[visit(child.key)] = visit(child.value)
         hash
       end
+    end
+
+    # Cannot handle arguments that are calls
+    def visit_call_node(_node)
+      nil
     end
 
     def visit_symbol_node(node)

--- a/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
@@ -229,6 +229,9 @@ module I18n::Tasks::Scanners::PrismScanners
 
     def rails_handle_model_name(node)
       _args, kwargs = process_arguments(node)
+      # TODO: Handle calls without a class, e.g. when called inside a model model_name.human(count: 2)
+      return if node.receiver.receiver.nil?
+
       model_name = node.receiver.receiver.name.to_s.underscore
 
       count_key = (kwargs['count'] || 0) > 1 ? 'other' : 'one'
@@ -245,12 +248,11 @@ module I18n::Tasks::Scanners::PrismScanners
 
     def rails_handle_human_attribute_name(node)
       array_args, keywords = process_arguments(node)
-      unless array_args.size == 1 && keywords.empty?
-        fail(
-          ArgumentError,
-          'human_attribute_name should have only one argument'
-        )
-      end
+      # Arguments empty or cannot be processed, e.g. if it is a call
+      return unless array_args.size == 1 && keywords.empty?
+
+      # TODO: Handle calls without a class, e.g. when called inside a model human_attribute_name(:name)
+      return if node.receiver.nil?
 
       key = [
         :activerecord,

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -250,6 +250,24 @@ RSpec.describe 'PrismScanner' do
           Event.human_attribute_name(:title)
           Event.model_name.human(count: 2)
           Event.model_name.human
+
+          class Event < ApplicationRecord
+            def to_s
+              model_name.human(count: 1)
+            end
+
+            def category
+              human_attribute_name(:category)
+            end
+
+            def key
+              :category
+            end
+
+            def value
+              human_attribute_name(key)
+            end
+          end
         RUBY
 
         occurrences = process_string('app/models/event.rb', source)
@@ -401,8 +419,11 @@ RSpec.describe 'PrismScanner' do
     describe 'translation options' do
       it 'handles scope' do
         source = <<~RUBY
+          scope = 'special.events'
           t('scope_string', scope: 'events.descriptions')
           I18n.t('scope_array', scope: ['events', 'titles'])
+          I18n.t(model.key, **translation_options(model))
+          I18n.t("success", scope: scope)
         RUBY
 
         occurrences = process_string('scope.rb', source)


### PR DESCRIPTION
- Fixes errors with invalid scopes
- Skips {model_name.human, human_attribute_name} calls without receiver
  In the future we want to support these calls where we can infer
  the receiver context.
