### PR TITLE
Prism: Uses built-in comments handling

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanner.rb
+++ b/lib/i18n/tasks/scanners/prism_scanner.rb
@@ -38,14 +38,14 @@ module I18n::Tasks::Scanners
 
     # Need to have method that can be overridden to be able to test it
     def process_results(path, parse_results)
+      comments = parse_results.attach_comments!
       parsed = parse_results.value
-      comments = parse_results.comments
 
       return @fallback.send(:scan_file, path) if skip_prism_comment?(comments)
 
       rails = config[:prism_visitor].blank? || config[:prism_visitor] != 'ruby'
 
-      visitor = VISITOR.new(comments: comments, rails: rails)
+      visitor = VISITOR.new(rails: rails)
       parsed.accept(visitor)
 
       occurrences = []

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -346,9 +346,9 @@ RSpec.describe 'PrismScanner' do
         expect(occurrence.path).to eq(
           'spec/fixtures/used_keys/app/controllers/a.rb'
         )
-        expect(occurrence.line_num).to eq(7)
+        expect(occurrence.line_num).to eq(4)
         expect(occurrence.line).to eq(
-          "# i18n-tasks-use t('translation.from.comment3')"
+          "I18n.t(\"scoped.translation.\#{variable}\")"
         )
       end
 


### PR DESCRIPTION
- Avoids the logic for connecting commens to the correct line,
  leave it to Prism.
- Changes the behavior for commens added without e.g. a method call
  on a following line. It will then be connected to the previous line.
