### PR TITLE
Gemspec: Removes upper required_ruby_version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.4", "3.3", "3.2", "3.1", "jruby"]
+        ruby-version: ["3.4", "3.3", "3.2", "3.1", "jruby", "head"]
       fail-fast: false
 
     env:

--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => 'https://github.com/glebm/i18n-tasks'
   }
-  s.required_ruby_version = '>= 3.1', '< 4.0'
+  s.required_ruby_version = '>= 3.1'
 
   s.files = `git ls-files`.split($/)
   s.files -= s.files.grep(%r{^(doc/|\.|spec/)}) + %w[CHANGES.md config/i18n-tasks.yml Gemfile]


### PR DESCRIPTION
- The syntax seems to be incorrect for Dependabot
- Rubygems does not document a way to add upper bounds:
https://guides.rubygems.org/specification-reference/#required_ruby_version

Here is the failing dependabot update:
https://github.com/glebm/i18n-tasks/actions/runs/14946390024/job/41990247982
