### PR TITLE
Chore: Fixes rubocop Lint/RescueException

### DIFF
--- a/lib/i18n/tasks/data/file_formats.rb
+++ b/lib/i18n/tasks/data/file_formats.rb
@@ -21,7 +21,7 @@ module I18n
 
         def adapter_op(op, format, tree, config)
           self.class.adapter_by_name(format).send(op, tree, config)
-        rescue Exception => e # rubocop:disable Lint/RescueException
+        rescue StandardError => e
           raise CommandError, "#{format} #{op} error: #{e.message}"
         end
 

--- a/lib/i18n/tasks/scanners/pattern_scanner.rb
+++ b/lib/i18n/tasks/scanners/pattern_scanner.rb
@@ -53,7 +53,7 @@ module I18n::Tasks::Scanners
         keys << [key, location]
       end
       keys
-    rescue Exception => e # rubocop:disable Lint/RescueException
+    rescue StandardError => e
       raise ::I18n::Tasks::CommandError.new(e, "Error scanning #{path}: #{e.message}")
     end
 

--- a/lib/i18n/tasks/scanners/prism_scanner.rb
+++ b/lib/i18n/tasks/scanners/prism_scanner.rb
@@ -27,7 +27,7 @@ module I18n::Tasks::Scanners
       return @fallback.send(:scan_file, path) if VISITOR.nil?
 
       process_results(path, PARSER.parse_file(path))
-    rescue Exception => e # rubocop:disable Lint/RescueException
+    rescue StandardError => e
       raise(
         ::I18n::Tasks::CommandError.new(
           e,

--- a/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_ast_scanner.rb
@@ -32,7 +32,7 @@ module I18n::Tasks::Scanners
       ast, comments = path_to_ast_and_comments(path)
 
       ast_to_occurences(ast) + comments_to_occurences(path, ast, comments)
-    rescue Exception => e # rubocop:disable Lint/RescueException
+    rescue StandardError => e
       raise ::I18n::Tasks::CommandError.new(e, "Error scanning #{path}: #{e.message}")
     end
 


### PR DESCRIPTION
- Rescues from StandardError instead of Exception
