### PR TITLE
Use configured glossary ID as fallback for Deepl Free plan

### DIFF
--- a/lib/i18n/tasks/translators/deepl_translator.rb
+++ b/lib/i18n/tasks/translators/deepl_translator.rb
@@ -111,9 +111,12 @@ module I18n::Tasks::Translators
       end
     end
 
+    # The Free API endpoint doesn’t expose glossaries via DeepL.glossaries.list,
+    # so if no API-backed glossary is found, fall back to the first ID from i18n-config.yml.
     def options_with_glossary(options, from, to)
-      glossary = find_glossary(from, to)
-      glossary ? { glossary_id: glossary.id }.merge(options) : options
+      configured = @i18n_tasks.translation_config[:deepl_glossary_ids]
+      gid = find_glossary(from, to)&.id || configured&.first
+      gid ? { glossary_id: gid }.merge(options) : options
     end
 
     def all_ready_glossaries


### PR DESCRIPTION
Problem: When using the DeepL API Free plan, `DeepL.glossaries.list` always returns `nil`—even if you’ve defined one or more IDs in your i18n-config.yml—because glossary management isn’t supported on Free. As a result, i18n-tasks can’t apply any glossaries.

Solution: Fall back to the IDs in i18n-config.yml when the API returns no glossaries.