### PR TITLE
Fix docs typo in Psych normalization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ a: |
   Lorem ipsum dolor sit amet, consectetur
 b: "Lorem ipsum dolor sit amet, consectetur \nLorem ipsum dolor sit amet, consectetur\n"
 ```
-The only difference between `a` and `b` is that `a` has an extra space in the first line.
+The only difference between `a` and `b` is that `b` has an extra trailing space in each line.
 This is an unfortunate side effect of `i18n-tasks` using `Psych`.
 
 #### `t()` keyword arguments


### PR DESCRIPTION
### Documentation

Small correction to the "Unexpected normalization" section. Fixed which variable has the trailing spaces. Comment initially made at https://github.com/glebm/i18n-tasks/pull/570#discussion_r1597508606.