### PR TITLE
Adds support for dotenv

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ to use the Prism Scanner without Rails support.
   - The Prism-based scanner handles comments differently vs the `whitequark/parser`-based scanner does.
   - The usage will be for the magic comment line instead of the subsequent line.
   - This should not affect the results of the CLI tasks.
+- Loads environment variables via `dotenv` if available. [#395](https://github.com/glebm/i18n-tasks/issues/395)
   
 ## v1.0.15
 

--- a/README.md
+++ b/README.md
@@ -413,6 +413,24 @@ For more complex cases, you can implement a [custom scanner][custom-scanner-docs
 
 See the [config file][config] to find out more.
 
+### Environment Variables and Dotenv
+
+i18n-tasks supports loading environment variables from `.env` files using the [dotenv](https://github.com/bkeepers/dotenv) gem.
+This is particularly useful for storing translation API keys and other sensitive configuration.
+
+If you have `dotenv` in your Gemfile, i18n-tasks will automatically load environment variables from `.env` files
+before executing commands. This means you can store your API keys in a `.env` file:
+
+```bash
+# .env
+GOOGLE_TRANSLATE_API_KEY=your_google_api_key
+DEEPL_AUTH_KEY=your_deepl_api_key
+OPENAI_API_KEY=your_openai_api_key
+```
+
+The dotenv integration works seamlessly - no additional configuration is required. If `dotenv` is not available,
+i18n-tasks will continue to work normally using system environment variables.
+
 <a name="google-translation-config"></a>
 ### Google Translate
 

--- a/lib/i18n/tasks/cli.rb
+++ b/lib/i18n/tasks/cli.rb
@@ -12,6 +12,8 @@ class I18n::Tasks::CLI
   end
 
   def start(argv)
+    load_dotenv
+
     auto_output_coloring do
       exit 1 if run(argv) == :exit1
     rescue OptionParser::ParseError => e
@@ -209,5 +211,12 @@ class I18n::Tasks::CLI
     yield
   ensure
     Rainbow.enabled = coloring_was
+  end
+
+  def load_dotenv
+    require "dotenv"
+    Dotenv.load
+  rescue LoadError
+    # dotenv not available, continue without it
   end
 end

--- a/spec/dotenv_integration_spec.rb
+++ b/spec/dotenv_integration_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Dotenv integration" do
+  describe "CLI dotenv loading" do
+    let(:cli) { I18n::Tasks::CLI.new }
+
+    context "when dotenv is available" do
+      it "attempts to load dotenv" do
+        # Mock dotenv to be available - using class_double for verification
+        mock_dotenv = class_double("Dotenv") # rubocop:disable RSpec/VerifiedDoubleReference
+        expect(mock_dotenv).to receive(:load)
+        stub_const("Dotenv", mock_dotenv)
+
+        # Mock the require to succeed
+        allow(cli).to receive(:require).and_call_original
+        allow(cli).to receive(:require).with("dotenv").and_return(true)
+
+        # Call the load_dotenv method directly
+        cli.send(:load_dotenv)
+      end
+    end
+
+    context "when dotenv is not available" do
+      it "handles LoadError gracefully" do
+        # Mock the require to raise LoadError
+        allow(cli).to receive(:require).and_call_original
+        allow(cli).to receive(:require).with("dotenv").and_raise(LoadError)
+
+        # Should not raise an error
+        expect { cli.send(:load_dotenv) }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
- If dotenv is available, we load it before every task.
- This allows users to easily load environment variables from an .env file
- Fixes #395
