### PR TITLE
Add per-locale custom prompts for OpenAI translations

### DIFF
--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -70,6 +70,7 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
       conf[:deepl_version] = ENV["DEEPL_VERSION"] if ENV.key?("DEEPL_VERSION")
       conf[:openai_api_key] = ENV["OPENAI_API_KEY"] if ENV.key?("OPENAI_API_KEY")
       conf[:openai_model] = ENV["OPENAI_MODEL"] if ENV.key?("OPENAI_MODEL")
+      conf[:openai_locale_prompts] ||= {}
       conf[:watsonx_api_key] = ENV["WATSONX_API_KEY"] if ENV.key?("WATSONX_API_KEY")
       conf[:watsonx_project_id] = ENV["WATSONX_PROJECT_ID"] if ENV.key?("WATSONX_PROJECT_ID")
       conf[:watsonx_model] = ENV["WATSONX_MODEL"] if ENV.key?("WATSONX_MODEL")

--- a/templates/config/i18n-tasks.yml
+++ b/templates/config/i18n-tasks.yml
@@ -128,6 +128,17 @@ search:
 #   #   You are a professional translator that translates content from the %{from} locale
 #   #   to the %{to} locale in an i18n locale array.
 #   #
+#   # Per-locale prompts override the default prompt for specific target locales
+#   # openai_locale_prompts:
+#   #   es: >-
+#   #     You are a professional translator specializing in Latin American Spanish.
+#   #     Translate content from the %{from} locale to the %{to} locale, using informal language
+#   #     and regional expressions common in Mexico.
+#   #   ja: >-
+#   #     You are a professional translator specializing in business Japanese.
+#   #     Translate content from the %{from} locale to the %{to} locale using formal, professional
+#   #     language appropriate for business contexts.
+#   #
 #   #   The array has a structured format and contains multiple strings. Your task is to translate
 #   #   each of these strings and create a new array with the translated strings.
 #   #


### PR DESCRIPTION
Allow users to configure locale-specific system prompts for OpenAI translations to improve translation quality with context-aware instructions for each target locale.

This enables users to provide specialized translation instructions per locale, such as formal/informal tone, regional variations, or domain-specific context.

Example configuration:

  openai_locale_prompts:
    es: "Use informal Latin American Spanish..."
    ja: "Use formal business Japanese..."

I have been using this extensively as it significantly improves the translation quality and consistency.