### PR TITLE
Require highline >= 3.0.0 so Ruby 3.4 and newer works

### DIFF
--- a/i18n-tasks.gemspec
+++ b/i18n-tasks.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 4.0.2"
   s.add_dependency "ast", ">= 2.1.0"
   s.add_dependency "erubi"
-  s.add_dependency "highline", ">= 2.0.0"
+  s.add_dependency "highline", ">= 3.0.0"
   s.add_dependency "i18n"
   s.add_dependency "parser", ">= 3.2.2.1"
   s.add_dependency "prism"


### PR DESCRIPTION
Without this you get an error regarding `abbrev` no longer being a default gem.

/Users/jarrett/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/highline-2.0.3/lib/highline.rb:17: warning: abbrev was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.