### PR TITLE
Chore: Ignores rubocop warning

### DIFF
--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -298,7 +298,7 @@ RSpec.describe "PrismScanner" do
       )
     end
 
-    it "rails model translations" do
+    it "rails model translations" do # rubocop:disable RSpec/MultipleExpectations
       source = <<~RUBY
         Event.human_attribute_name(:title)
         Event.model_name.human(count: 2)


### PR DESCRIPTION
- For blocks in rails controllers we did not include translations
  called directly from the controller properly.
- Fixes `count` to `model_name.human` passed as string
- Added tests for these cases
