### PR TITLE
Prism: Supports candidate_keys for each occurrence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ to use the Prism Scanner without Rails support.
   - This should not affect the results of the CLI tasks.
 - Loads environment variables via `dotenv` if available. [#395](https://github.com/glebm/i18n-tasks/issues/395)
 - Adds CLI command `check_prism` to try the new parser out and see the differences in key detection.
+- The Prism-based scanner supports candidate_keys for Rails translations, allowing relative translations in controllers to match either the key scoped to controller and action or only to the controller.
 
 ## v1.0.15
 

--- a/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
@@ -98,25 +98,36 @@ module I18n::Tasks::Scanners::PrismScanners
       occurrence(file_path)
     end
 
+    # Returns either a single key string or an array of candidate key strings for this call.
     def full_key
       return nil if key.nil?
       return nil unless key.is_a?(String)
       return nil if relative_key? && !support_relative_keys?
 
-      parts = [scope]
+      base_parts = [scope].compact
 
       if relative_key?
-        parts.concat(parent&.path || [])
-        parts << key
+        # For relative keys in controllers/methods, generate candidate keys by
+        # progressively stripping trailing path segments from the parent path.
+        # Example: parent.path = ["events", "create"], key = ".success"
+        # yields: ["events.create.success", "events.success"]
+        parent_path = parent&.path || []
+        rel_key = key[1..] # strip leading dot # rubocop:disable Performance/ArraySemiInfiniteRangeSlice
 
-        # TODO: Fallback to controller without action name
+        candidates = []
+        parent_path_length = parent_path.length
+        # Do not generate an unscoped bare key (keep_count = 0). Start from full parent path
+        parent_path_length.downto(1) do |keep_count|
+          parts = base_parts + parent_path.first(keep_count) + [rel_key]
+          candidates << parts.compact.join(".")
+        end
+
+        candidates.map { |c| c.gsub("..", ".") }
       elsif key.start_with?(".")
-        parts << key[1..]  # rubocop:disable Performance/ArraySemiInfiniteRangeSlice
+        [base_parts + [key[1..]]].flatten.compact.join(".").gsub("..", ".") # rubocop:disable Performance/ArraySemiInfiniteRangeSlice,Performance/ChainArrayAllocation
       else
-        parts << key
+        [base_parts + [key]].flatten.compact.join(".").gsub("..", ".") # rubocop:disable Performance/ChainArrayAllocation
       end
-
-      parts.compact.join(".").gsub("..", ".")
     end
 
     private
@@ -135,20 +146,27 @@ module I18n::Tasks::Scanners::PrismScanners
 
       location = local_node.location
 
-      final_key = full_key
-      return nil if final_key.nil?
+      final = full_key
+      return nil if final.nil?
 
-      [
-        final_key,
-        ::I18n::Tasks::Scanners::Results::Occurrence.new(
-          path: file_path,
-          line: local_node.respond_to?(:slice) ? local_node.slice : local_node.location.slice,
-          pos: location.start_offset,
-          line_pos: location.start_column,
-          line_num: location.start_line,
-          raw_key: key
-        )
-      ]
+      occurrence = ::I18n::Tasks::Scanners::Results::Occurrence.new(
+        path: file_path,
+        line: local_node.respond_to?(:slice) ? local_node.slice : local_node.location.slice,
+        pos: location.start_offset,
+        line_pos: location.start_column,
+        line_num: location.start_line,
+        raw_key: key
+      )
+
+      # full_key may be a single String or an Array of candidate strings
+      if final.is_a?(Array)
+        # record candidate keys on the occurrence (first candidate is the primary)
+        occurrence.instance_variable_set(:@candidate_keys, final)
+        [final.first, occurrence]
+      else
+        occurrence.instance_variable_set(:@candidate_keys, [final])
+        [final, occurrence]
+      end
     rescue ScopeError
       nil
     end

--- a/lib/i18n/tasks/scanners/results/occurrence.rb
+++ b/lib/i18n/tasks/scanners/results/occurrence.rb
@@ -28,6 +28,9 @@ module I18n::Tasks
         # @return [String, nil] the raw key (for relative keys and references)
         attr_accessor :raw_key
 
+        # @return [Array<String>, nil] candidate keys that may be used at runtime
+        attr_reader :candidate_keys
+
         # @param path        [String]
         # @param pos         [Integer]
         # @param line_num    [Integer]
@@ -36,7 +39,7 @@ module I18n::Tasks
         # @param raw_key     [String, nil]
         # @param default_arg [String, nil]
         # rubocop:disable Metrics/ParameterLists
-        def initialize(path:, pos:, line_num:, line_pos:, line:, raw_key: nil, default_arg: nil)
+        def initialize(path:, pos:, line_num:, line_pos:, line:, raw_key: nil, default_arg: nil, candidate_keys: nil)
           @path = path
           @pos = pos
           @line_num = line_num
@@ -44,16 +47,17 @@ module I18n::Tasks
           @line = line
           @raw_key = raw_key
           @default_arg = default_arg
+          @candidate_keys = candidate_keys
         end
         # rubocop:enable Metrics/ParameterLists
 
         def inspect
-          "Occurrence(#{@path}:#{@line_num}, line_pos: #{@line_pos}, pos: #{@pos}, raw_key: #{@raw_key}, default_arg: #{@default_arg}, line: #{@line})" # rubocop:disable Layout/LineLength
+          "Occurrence(#{@path}:#{@line_num}, line_pos: #{@line_pos}, pos: #{@pos}, raw_key: #{@raw_key}, candidate_keys: #{@candidate_keys}, default_arg: #{@default_arg}, line: #{@line})" # rubocop:disable Layout/LineLength
         end
 
         def ==(other)
           other.path == @path && other.pos == @pos && other.line_num == @line_num && other.line == @line &&
-            other.raw_key == @raw_key && other.default_arg == @default_arg
+            other.raw_key == @raw_key && other.default_arg == @default_arg && other.candidate_keys == @candidate_keys
         end
 
         def eql?(other)
@@ -61,7 +65,7 @@ module I18n::Tasks
         end
 
         def hash
-          [@path, @pos, @line_num, @line_pos, @line, @default_arg].hash
+          [@path, @pos, @line_num, @line_pos, @line, @default_arg, @candidate_keys].hash
         end
 
         # @param raw_key [String]

--- a/lib/i18n/tasks/scanners/ruby_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_scanner.rb
@@ -90,7 +90,13 @@ module I18n::Tasks::Scanners
               nil,
               location: associated_node || comment.location
             )
-            results << result if result
+            next unless result
+
+            if result.is_a?(Array) && result.first.is_a?(Array)
+              results.concat(result)
+            else
+              results << result
+            end
           end
         end
 
@@ -108,7 +114,13 @@ module I18n::Tasks::Scanners
       calls.each do |send_node, method_name|
         @matchers.each do |matcher|
           result = matcher.convert_to_key_occurrences(send_node, method_name)
-          results << result if result
+          next unless result
+
+          if result.is_a?(Array) && result.first.is_a?(Array)
+            results.concat(result)
+          else
+            results << result
+          end
         end
       end
 
@@ -176,7 +188,13 @@ module I18n::Tasks::Scanners
       occurrences = []
       visitor.process.each do |translation_call|
         result = translation_call.occurrences(path)
-        occurrences << result if result
+        next unless result
+
+        if result.is_a?(Array) && result.first.is_a?(Array)
+          occurrences.concat(result)
+        else
+          occurrences << result
+        end
       end
 
       occurrences

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -66,6 +66,30 @@ RSpec.describe "PrismScanner" do
       )
     end
 
+    it "controller - relative key" do
+      source = <<~RUBY
+        class EventsController < ApplicationController
+          def create
+            t('.relative_key')
+          end
+        end
+      RUBY
+
+      occurrences =
+        process_string("app/controllers/events_controller.rb", source)
+      expect(occurrences.map(&:first).uniq).to match_array(
+        %w[events.create.relative_key]
+      )
+
+      # Check candidate_keys
+      expect(occurrences.map { |o| o.last.candidate_keys }.flatten.uniq).to match_array(
+        %w[
+          events.create.relative_key
+          events.relative_key
+        ]
+      )
+    end
+
     it "empty controller" do
       source = <<~RUBY
         class ApplicationController < ActionController::Base


### PR DESCRIPTION
- When translating with some rails methods or relative keys, it
  allows for multiple possible keys at runtime.
- A relative key like `.success` inside a controller action can resolve
  to either `<controller_name>.<action_name>.success` or
  `<controller_name>.success`.
- By allowing the scanner to return these candidate keys as well
  and check for an occurrence in missing_keys we can support them
  both.
