### PR TITLE
Removes codeclimate and runs rubocop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,6 @@ jobs:
       fail-fast: false
 
     env:
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
       GOOGLE_TRANSLATE_API_KEY: ${{ secrets.GOOGLE_TRANSLATE_API_KEY }}
       COVERAGE: 1
       RUBYOPT: "--enable-frozen-string-literal --debug-frozen-string-literal"
@@ -45,16 +44,7 @@ jobs:
           bundler-cache: ${{ matrix.ruby-version != 'head' }}
           bundler: latest
           rubygems: latest
-      - name: "Determine whether to upload coverage"
-        if: ${{ env.CC_TEST_REPORTER_ID && startsWith(matrix.ruby-version, '3.4') && github.ref == 'refs/heads/main' }}
-        run: echo UPLOAD_COVERAGE=1 >> $GITHUB_ENV
       - name: Install dependencies
         run: bundle install
       - name: Run tests
-        if: ${{ !env.UPLOAD_COVERAGE }}
         run: bundle exec rake
-      - name: Run tests and upload coverage
-        uses: paambaati/codeclimate-action@v9
-        if: ${{ env.UPLOAD_COVERAGE }}
-        with:
-          coverageCommand: bundle exec rake

--- a/lib/i18n/tasks/scanners/erb_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/erb_ast_scanner.rb
@@ -9,6 +9,7 @@ module I18n::Tasks::Scanners
   # Scan for I18n.translate calls in ERB-file using regexp and Parser/Prism
   class ErbAstScanner < RubyScanner
     include OccurrenceFromPosition
+
     DEFAULT_REGEXP = /<%(={1,2}|-|\#-?|%)?(.*?)([-=])?%>/m
 
     # Parser scanner, method called in RubyScanner

--- a/lib/i18n/tasks/translators/base_translator.rb
+++ b/lib/i18n/tasks/translators/base_translator.rb
@@ -6,6 +6,7 @@ module I18n::Tasks
   module Translators
     class BaseTranslator
       include ::I18n::Tasks::Logging
+
       # @param [I18n::Tasks::BaseTask] i18n_tasks
       def initialize(i18n_tasks)
         @i18n_tasks = i18n_tasks

--- a/lib/i18n/tasks/translators/openai_translator.rb
+++ b/lib/i18n/tasks/translators/openai_translator.rb
@@ -6,6 +6,7 @@ require "active_support/core_ext/string/filters"
 module I18n::Tasks::Translators
   class OpenAiTranslator < BaseTranslator
     include ::I18n::Tasks::Data::LanguageNames
+
     # max allowed texts per request
     BATCH_SIZE = 50
     DEFAULT_SYSTEM_PROMPT = <<~PROMPT.squish

--- a/spec/i18n_tasks_spec.rb
+++ b/spec/i18n_tasks_spec.rb
@@ -213,11 +213,11 @@ RSpec.describe "i18n-tasks" do
 
     it "detects missing" do
       es_keys = expected_missing_keys_diff.grep(/^es\./) +
-        (expected_missing_keys_in_source.map { |k| (k[0] == "⮕") ? k : "es.#{k}" })
+        expected_missing_keys_in_source.map { |k| (k[0] == "⮕") ? k : "es.#{k}" }
       out, result = run_cmd_capture_stdout_and_result "missing"
       expect(result).to eq :exit1
       expect(out).to be_i18n_keys(expected_missing_keys_diff +
-                                      (expected_missing_keys_in_source.map { |k| (k[0] == "⮕") ? k : "all.#{k}" }))
+                                      expected_missing_keys_in_source.map { |k| (k[0] == "⮕") ? k : "all.#{k}" })
       expect(run_cmd("missing", "-les")).to be_i18n_keys es_keys
       expect(run_cmd("missing", "es")).to be_i18n_keys es_keys
     end

--- a/spec/key_pattern_matching_spec.rb
+++ b/spec/key_pattern_matching_spec.rb
@@ -4,6 +4,7 @@ require "spec_helper"
 
 RSpec.describe "Key pattern" do
   include I18n::Tasks::KeyPatternMatching
+
   describe "matching" do
     describe "*" do
       it "as suffix" do


### PR DESCRIPTION
- Apparently codeclimate is deprecated and replaced by
  https://docs.qlty.sh/migration/coverage
- Runs `bundle exec rubocop -a`
