### PR TITLE
Prism: Detects more invalid scopes

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
@@ -140,9 +140,9 @@ module I18n::Tasks::Scanners::PrismScanners
       return nil if @options.nil?
       return nil unless @options["scope"]
 
-      fail(ScopeError, "Could not process scope") if @options.key?("scope") && Array(@options["scope"]).empty?
+      fail(ScopeError, "Could not process scope") if @options.key?("scope") && (Array(@options["scope"]).empty? || !Array(@options["scope"]).all? { |s| s.is_a?(String) || s.is_a?(Symbol) })
 
-      Array(@options["scope"]).compact.map(&:to_s).join(".")
+      Array(@options["scope"]).join(".")
     end
 
     def occurrence(file_path)


### PR DESCRIPTION
- Scopes containing variables or unknowns cannot be handled
  and need to be ignored.
- It allowed empty arrays or nodes that evaluated to empty strings.
