### PR TITLE
Correct Env in README from DEEPL_API_KEY to DEEPL_AUTH_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ translation:
 or via environment variables:
 
 ```bash
-DEEPL_API_KEY=<DeepL Pro API key>
+DEEPL_AUTH_KEY=<DeepL Pro API key>
 DEEPL_HOST=<optional>
 DEEPL_VERSION=<optional>
 ```


### PR DESCRIPTION
ENV name is DEEPL_AUTH_KEY