### PR TITLE
Prism: model_name.human handles more count values

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
@@ -276,12 +276,12 @@ module I18n::Tasks::Scanners::PrismScanners
 
       # Handle count being a symbol, e.g. count: :other
       count_key = case kwargs["count"]
-      when Symbol, String
-        kwargs["count"].to_s
       when Integer
         (kwargs["count"] > 1) ? "other" : "one"
-      else
+      when "one", :one, nil
         "one"
+      else
+        "other"
       end
 
       parent.add_translation_call(

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -325,8 +325,9 @@ RSpec.describe "PrismScanner" do
     it "rails - model_name.human" do # rubocop:disable RSpec/MultipleExpectations
       source = <<~RUBY
         Event.model_name.human(count: 2)
-        Participant.model_name.human(count: :other)
         Event.model_name.human
+        Participant.model_name.human(count: :other)
+        Participant.model_name.human(count: :random_key_becomes_plural)
       RUBY
 
       occurrences = process_string("app/lib/script.rb", source)
@@ -335,6 +336,7 @@ RSpec.describe "PrismScanner" do
         %w[
           activerecord.models.event.one
           activerecord.models.event.other
+          activerecord.models.participant.other
           activerecord.models.participant.other
         ]
       )
@@ -346,16 +348,22 @@ RSpec.describe "PrismScanner" do
       expect(occurrence.line).to eq("Event.model_name.human(count: 2)")
 
       occurrence = occurrences[1].last
-      expect(occurrence.raw_key).to eq("activerecord.models.participant.other")
-      expect(occurrence.path).to eq("app/lib/script.rb")
-      expect(occurrence.line_num).to eq(2)
-      expect(occurrence.line).to eq("Participant.model_name.human(count: :other)")
-
-      occurrence = occurrences[2].last
       expect(occurrence.raw_key).to eq("activerecord.models.event.one")
       expect(occurrence.path).to eq("app/lib/script.rb")
-      expect(occurrence.line_num).to eq(3)
+      expect(occurrence.line_num).to eq(2)
       expect(occurrence.line).to eq("Event.model_name.human")
+
+      occurrence = occurrences[2].last
+      expect(occurrence.raw_key).to eq("activerecord.models.participant.other")
+      expect(occurrence.path).to eq("app/lib/script.rb")
+      expect(occurrence.line_num).to eq(3)
+      expect(occurrence.line).to eq("Participant.model_name.human(count: :other)")
+
+      occurrence = occurrences[3].last
+      expect(occurrence.raw_key).to eq("activerecord.models.participant.other")
+      expect(occurrence.path).to eq("app/lib/script.rb")
+      expect(occurrence.line_num).to eq(4)
+      expect(occurrence.line).to eq("Participant.model_name.human(count: :random_key_becomes_plural)")
     end
 
     it "rails - human_attribute_name" do


### PR DESCRIPTION
- Passing a random string or symbol as `count` returns the pluralized
  translation, so lets default to that.
