### PR TITLE
Prism: Skip cyclic methods instead of failing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,9 +22,10 @@ to use the Prism Scanner without Rails support.
   - The usage will be for the magic comment line instead of the subsequent line.
   - This should not affect the results of the CLI tasks.
 - Loads environment variables via `dotenv` if available. [#395](https://github.com/glebm/i18n-tasks/issues/395)
-- Adds CLI command `check_prism` to try the new parser out and see the differences in key detection.
+- Adds CLI command `check-prism` to try the new parser out and see the differences in key detection.
 - The Prism-based scanner supports candidate_keys for Rails translations, allowing relative translations in controllers to match either the key scoped to controller and action or only to the controller.
 - Translation services now catch errors and save partial results [#642](https://github.com/glebm/i18n-tasks/issues/642)
+- Prism: Skips translations form cyclic calls instead of throwing error.
 
 ## v1.0.15
 

--- a/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
@@ -272,7 +272,7 @@ module I18n::Tasks::Scanners::PrismScanners
           nested_calls[method.name] << other_method.name
 
           if nested_calls[call.name]&.include?(method.name)
-            fail(ArgumentError, "Cyclic call detected: #{call.name} -> #{method.name}")
+            next
           end
 
           other_method.translation_calls.each do |translation_call|


### PR DESCRIPTION
- When parsing relative translations in controllers we need to
  keep track of cyclic calls to avoid infinite loops.
- Previously an error was raised, but now we simply skip
  translations found in cyclic calls.

Fixes #677
