### PR TITLE
Gemfile: Removes bundler, rbx and byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in i18n-tasks.gemspec
 gemspec
 
-platform :rbx do
-  # https://github.com/rubinius/rubinius/issues/2632
-  gem "racc"
-end
-
-gem "bundler", "~> 2.0", ">= 2.0.1"
 gem "overcommit"
 gem "rake"
 gem "rspec", "~> 3.3"
@@ -25,10 +19,3 @@ gem "yard"
 gem "deepl-rb", ">= 2.1.0"
 gem "ruby-openai"
 gem "yandex-translator", ">= 0.3.3"
-
-unless ENV["CI"]
-  group :development do
-    gem "byebug", platforms: %i[mri mswin x64_mingw_21 x64_mingw_22], require: false # rubocop:disable Naming/VariableNumber
-    gem "rubinius-debugger", platform: :rbx, require: false
-  end
-end


### PR DESCRIPTION
- Removes bundler limit to work with bundler 4 beta on ruby-head
- Removes byebug and rbx gems
