### PR TITLE
ScannerMultiplexer: Removes concurrency due to bug

### DIFF
--- a/lib/i18n/tasks/scanners/erb_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/erb_ast_scanner.rb
@@ -3,7 +3,6 @@
 require "i18n/tasks/scanners/ruby_scanner"
 require "i18n/tasks/scanners/local_ruby_parser"
 require "i18n/tasks/scanners/occurrence_from_position"
-require "prism"
 
 module I18n::Tasks::Scanners
   # Scan for I18n.translate calls in ERB-file using regexp and Parser/Prism

--- a/lib/i18n/tasks/scanners/scanner_multiplexer.rb
+++ b/lib/i18n/tasks/scanners/scanner_multiplexer.rb
@@ -4,8 +4,6 @@ require "i18n/tasks/scanners/scanner"
 
 module I18n::Tasks::Scanners
   # Run multiple {Scanner Scanners} and merge their results.
-  # @note The scanners are run concurrently. A thread is spawned per each scanner.
-  # @since 0.9.0
   class ScannerMultiplexer < Scanner
     # @param scanners [Array<Scanner>]
     def initialize(scanners:)
@@ -15,29 +13,10 @@ module I18n::Tasks::Scanners
 
     # Collect the results of all the scanners. Occurrences of a key from multiple scanners are merged.
     #
-    # @note The scanners are run concurrently. A thread is spawned per each scanner.
     # @return (see Scanner#keys)
     def keys
-      Results::KeyOccurrences.merge_keys collect_results.flatten(1)
-    end
-
-    private
-
-    # @return [Array<Array<Results::KeyOccurrences>>]
-    def collect_results
-      return [@scanners[0].keys] if @scanners.length == 1
-
-      Array.new(@scanners.length).tap do |results|
-        results_mutex = Mutex.new
-        @scanners.map.with_index do |scanner, i|
-          Thread.start do
-            scanner_results = scanner.keys
-            results_mutex.synchronize do
-              results[i] = scanner_results
-            end
-          end
-        end.each(&:join)
-      end
+      results = @scanners.map(&:keys)
+      Results::KeyOccurrences.merge_keys results.flatten(1)
     end
   end
 end


### PR DESCRIPTION
- Fixes #682
- Release 1.1.0 started causing errors for active_admin, the test
  suite would be intermittently failing on Ruby 3.2 and 3.3.
- When calling `warn` it would fail to write any output, possibly
  due to thread safety issues with IO objects.
- This change removes the concurrency in ScannerMultiplexer,
  reverting to a sequential execution of the scanners.
- If we want parallelism in teh future we should consider writing
  something with Ractors, conrurrent-ruby or the parallel gem.
