### PR TITLE
Adds `require 'prism'` to scanners using Prism

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,14 @@
+## Unreleased
+
+- Prism: Missing `require 'prism'` in the scanners fixed.
+
 ## v1.1.1
 
-- Prism: Fixes `translate` calls on non-I18n receivers being processed.
-- Prism: Adds candidate keys for model_name.human and human_attribute_name.
+- Prism: Fixes `translate` calls on non-I18n receivers being processed. (https://github.com/glebm/i18n-tasks/pull/684)
+- Prism: Adds candidate keys for model_name.human and human_attribute_name. (https://github.com/glebm/i18n-tasks/pull/684)
   - `Event.human_attribute_name(:title)` will now match `activerecord.attributes.event.title` or `attributes.title`.
-- Prism: Candidate keys were not added to the `used_tree`.
-- Works around a concurrency bug by reverting to serial scanning.
+- Prism: Candidate keys were not added to the `used_tree`. (https://github.com/glebm/i18n-tasks/pull/684)
+- Works around a concurrency bug by reverting to serial scanning. (https://github.com/glebm/i18n-tasks/pull/687)
 
 ## v1.1.0
 

--- a/lib/i18n/tasks/scanners/erb_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/erb_ast_scanner.rb
@@ -3,6 +3,7 @@
 require "i18n/tasks/scanners/ruby_scanner"
 require "i18n/tasks/scanners/local_ruby_parser"
 require "i18n/tasks/scanners/occurrence_from_position"
+require "prism"
 
 module I18n::Tasks::Scanners
   # Scan for I18n.translate calls in ERB-file using regexp and Parser/Prism

--- a/lib/i18n/tasks/scanners/ruby_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_scanner.rb
@@ -9,6 +9,7 @@ require "i18n/tasks/scanners/ast_matchers/default_i18n_subject_matcher"
 require "i18n/tasks/scanners/ast_matchers/message_receivers_matcher"
 require "i18n/tasks/scanners/ast_matchers/rails_model_matcher"
 require "i18n/tasks/scanners/prism_scanners/visitor"
+require "prism"
 
 module I18n::Tasks::Scanners
   # Scan for I18n.translate calls using whitequark/parser primarily and Prism if configured.

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "spec_helper"
-require "prism"
 
 RSpec.describe "PrismScanner" do
   describe "controllers" do


### PR DESCRIPTION
- Maybe the extra require in one of the tests made it work without
  requiring it in the code.
