### PR TITLE
Restores warn for logging

### DIFF
--- a/lib/i18n/tasks/logging.rb
+++ b/lib/i18n/tasks/logging.rb
@@ -25,8 +25,7 @@ module I18n::Tasks::Logging
   def log_stderr(*args)
     # We don't want output from different threads to get intermixed.
     MUTEX.synchronize do
-      # Use $stderr directly to avoid issues with JRuby and thread safety
-      $stderr.puts(*args) # rubocop:disable Style/StderrPuts
+      warn(*args)
     end
   end
 


### PR DESCRIPTION
- Removed this to fix jruby, but maybe it was due to the concurrency
  removed in https://github.com/glebm/i18n-tasks/pull/687
