### PR TITLE
Unused keys: Handles false positives for child nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 - `check-prism` makes better comparison between parsers for candidate keys.
 - `ignore_missing` now supports per-locale syntax (just like `ignore_eq_base`), allowing you to ignore different keys for different locales. Backward compatible with the array syntax.
 - Prism now supports ViewComponents and its relative translations.
-- Unused keys are no longer reported as missing if their parent key is used.
+- Unused keys are no longer reported as unused if their parent key is used.
 
 ## v1.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `check-prism` makes better comparison between parsers for candidate keys.
 - `ignore_missing` now supports per-locale syntax (just like `ignore_eq_base`), allowing you to ignore different keys for different locales. Backward compatible with the array syntax.
 - Prism now supports ViewComponents and its relative translations.
+- Unused keys are no longer reported as missing if their parent key is used.
 
 ## v1.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - `prune` now supports `-k` / `--keep-order` to preserve the original key ordering in locale files, consistent with `remove-unused`. Also documents the `prune` command in the README.
 - Prism/Rails: Fix crash when `human_attribute_name` is called with an interpolated string argument. Also fix `RailsModelMatcher` producing spurious keys for non-static attribute arguments. [#728](https://github.com/glebm/i18n-tasks/pull/728)
 - Prism: Handles telling apart `scope` being falsey or not included in a translation call. [#731](https://github.com/glebm/i18n-tasks/pull/731)
+- Unused keys are no longer reported as missing if their parent key is used.
 
 ## v1.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@
 - `prune` now supports `-k` / `--keep-order` to preserve the original key ordering in locale files, consistent with `remove-unused`. Also documents the `prune` command in the README.
 - Prism/Rails: Fix crash when `human_attribute_name` is called with an interpolated string argument. Also fix `RailsModelMatcher` producing spurious keys for non-static attribute arguments. [#728](https://github.com/glebm/i18n-tasks/pull/728)
 - Prism: Handles telling apart `scope` being falsey or not included in a translation call. [#731](https://github.com/glebm/i18n-tasks/pull/731)
-- Unused keys are no longer reported as missing if their parent key is used.
+- Unused keys are no longer reported as unused if their parent key is used.
 
 ## v1.1.2
 

--- a/lib/i18n/tasks/unused_keys.rb
+++ b/lib/i18n/tasks/unused_keys.rb
@@ -26,8 +26,19 @@ module I18n
       # A key is considered used if it is directly used, or if one of its ancestors is used
       # (e.g. `t(:section)` covers `section.item.title`).
       def key_used?(key, used_key_names)
-        used_key_names.include?(key) ||
-          used_key_names.any? { |used| key.start_with?("#{used}.") }
+        return true if used_key_names.include?(key)
+
+        ancestor = key
+        loop do
+          next_ancestor = ancestor.sub(/\.[^.]+\z/, "")
+          break if next_ancestor == ancestor
+
+          return true if used_key_names.include?(next_ancestor)
+
+          ancestor = next_ancestor
+        end
+
+        false
       end
     end
   end

--- a/lib/i18n/tasks/unused_keys.rb
+++ b/lib/i18n/tasks/unused_keys.rb
@@ -13,12 +13,21 @@ module I18n
       # @param [String] locale
       # @param [Boolean] strict if true, do not match dynamic keys
       def unused_tree(locale: base_locale, strict: nil)
-        used_key_names = used_tree(strict: true).key_names
+        used_key_names = used_tree(strict: true).key_names.to_set
         collapse_plural_nodes!(data[locale].select_keys do |key, _node|
           !ignore_key?(key, :unused) &&
             (strict || !used_in_expr?(key)) &&
-            !used_key_names.include?(depluralize_key(key, locale))
+            !key_used?(depluralize_key(key, locale), used_key_names)
         end)
+      end
+
+      private
+
+      # A key is considered used if it is directly used, or if one of its ancestors is used
+      # (e.g. `t(:section)` covers `section.item.title`).
+      def key_used?(key, used_key_names)
+        used_key_names.include?(key) ||
+          used_key_names.any? { |used| key.start_with?("#{used}.") }
       end
     end
   end

--- a/spec/unused_keys_spec.rb
+++ b/spec/unused_keys_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Unused keys" do
+  let(:task) { I18n::Tasks::BaseTask.new }
+
+  # https://github.com/glebm/i18n-tasks/issues/713
+  # A leaf key usage (e.g. `t(:section)`) was shadowing/dropping nested keys under the
+  # same root (e.g. `section.item.title`) when building the used-keys tree, causing those
+  # nested keys to be falsely reported as unused.
+  describe "issue #713: leaf key must not shadow nested keys with the same root" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/i18n-tasks.yml" => {
+          "base_locale" => "en",
+          "locales" => ["en"],
+          "search" => {"paths" => ["app/"]}
+        }.to_yaml,
+        "config/locales/en.yml" => {
+          "en" => {
+            "section" => {
+              "item" => {
+                "title" => "Title",
+                "subtitle" => "Subtitle"
+              }
+            }
+          }
+        }.to_yaml,
+        "app/views/example.html.erb" => <<~ERB
+          <%= t("section.item.title") %>
+          <%= t("section.item.subtitle") %>
+          <%= t(:section) %>
+        ERB
+      )
+      TestCodebase.in_test_app_dir { ex.call }
+      TestCodebase.teardown
+    end
+
+    it "does not report nested keys as unused when a leaf key shares the same root" do
+      unused_key_names = task.unused_keys.key_names(root: true)
+      expect(unused_key_names).not_to include("en.section.item.title")
+      expect(unused_key_names).not_to include("en.section.item.subtitle")
+    end
+  end
+end


### PR DESCRIPTION
- When a parent node is used as the key, it causes false positives for
  its children.
- Fixes #713
