### PR TITLE
Prism: Detects plural usage for keys

### DIFF
--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -62,11 +62,15 @@ module I18n::Tasks
         next if required_keys.empty?
 
         tree = empty_forest
+        source_occs = nil
         plural_nodes data[locale] do |node|
+          full_key = node.full_key(root: false)
           children = node.children
           present_keys = Set.new(children.map { |c| c.key.to_sym })
-          next if ignore_key?(node.full_key(root: false), :missing)
+          next if ignore_key?(full_key, :missing)
           next if present_keys.superset?(required_keys)
+          source_occs ||= source_key_occurrences_map
+          next if key_used_only_without_count?(full_key, source_occs)
 
           tree[node.full_key] = node.derive(
             value: children.to_hash,
@@ -172,6 +176,46 @@ module I18n::Tasks
     end
 
     private
+
+    # Returns a Hash of { full_key => [occurrences] } for all keys detected in source.
+    def source_key_occurrences_map
+      @source_key_occurrences_map ||= {}.tap do |map|
+        used_tree(strict: true).keys do |key, node|
+          map[key] = node.data[:occurrences] || []
+        end
+      end
+    end
+
+    # Returns true when a key appears in the scanned source and *every* detected
+    # occurrence was made **without** a `count:` argument (i.e., `occurrence.plural`
+    # is explicitly `false` for all of them), OR when the Prism scanner is active
+    # and the key has no source occurrences at all (Prism would have detected any
+    # `count:` usage, so absence means the key is not a plural call).
+    #
+    # Returns false (do not skip the check) when:
+    #   - Any occurrence has `plural: true`: key is used as a plural call.
+    #   - Any occurrence has `plural: nil`: unknown (e.g., from a non-Prism scanner);
+    #     conservatively keep the existing behavior.
+    #   - The key is not in the source tree and Prism is not active: preserve the
+    #     existing behavior so partial locale overrides are still validated.
+    def key_used_only_without_count?(key, source_occs)
+      occs = source_occs[key]
+      if occs.nil? || occs.empty?
+        # When Prism is active it would have flagged count: usage if it existed.
+        # Keys absent from source are plain translation keys, not plural calls.
+        return prism_scanner_active?
+      end
+
+      occs.all? { |occ| occ.plural == false }
+    end
+
+    # Returns true if any configured scanner uses Prism, meaning the `plural` flag
+    # on occurrences is reliable (true/false rather than nil).
+    def prism_scanner_active?
+      @prism_scanner_active ||= search_config[:scanners].any? do |(class_name, args)|
+        args&.fetch(:prism, nil).present?
+      end
+    end
 
     def plural_keys_for_locale(locale)
       configuration = load_rails_i18n_pluralization!(locale)

--- a/lib/i18n/tasks/missing_keys.rb
+++ b/lib/i18n/tasks/missing_keys.rb
@@ -186,35 +186,21 @@ module I18n::Tasks
       end
     end
 
-    # Returns true when a key appears in the scanned source and *every* detected
-    # occurrence was made **without** a `count:` argument (i.e., `occurrence.plural`
-    # is explicitly `false` for all of them), OR when the Prism scanner is active
-    # and the key has no source occurrences at all (Prism would have detected any
-    # `count:` usage, so absence means the key is not a plural call).
+    # Returns true when every detected source occurrence of the key was made
+    # **without** a `count:` argument (i.e., `occurrence.plural` is explicitly
+    # `false` for all of them).
     #
     # Returns false (do not skip the check) when:
+    #   - The key has no source occurrences: we conservatively keep the existing
+    #     behavior so unused/dynamic keys are still validated.
     #   - Any occurrence has `plural: true`: key is used as a plural call.
     #   - Any occurrence has `plural: nil`: unknown (e.g., from a non-Prism scanner);
     #     conservatively keep the existing behavior.
-    #   - The key is not in the source tree and Prism is not active: preserve the
-    #     existing behavior so partial locale overrides are still validated.
     def key_used_only_without_count?(key, source_occs)
       occs = source_occs[key]
-      if occs.nil? || occs.empty?
-        # When Prism is active it would have flagged count: usage if it existed.
-        # Keys absent from source are plain translation keys, not plural calls.
-        return prism_scanner_active?
-      end
+      return false if occs.nil? || occs.empty?
 
       occs.all? { |occ| occ.plural == false }
-    end
-
-    # Returns true if any configured scanner uses Prism, meaning the `plural` flag
-    # on occurrences is reliable (true/false rather than nil).
-    def prism_scanner_active?
-      @prism_scanner_active ||= search_config[:scanners].any? do |(class_name, args)|
-        args&.fetch(:prism, nil).present?
-      end
     end
 
     def plural_keys_for_locale(locale)

--- a/lib/i18n/tasks/scanners/erb_ast_scanner.rb
+++ b/lib/i18n/tasks/scanners/erb_ast_scanner.rb
@@ -112,7 +112,8 @@ module I18n::Tasks::Scanners
             content,
             start + occurrence.pos,
             raw_key: occurrence.raw_key,
-            candidate_keys: occurrence.candidate_keys
+            candidate_keys: occurrence.candidate_keys,
+            plural: occurrence.plural
           )
         ]
       end
@@ -130,7 +131,8 @@ module I18n::Tasks::Scanners
             content,
             start + (code.index(key) || occurrence.pos),
             raw_key: occurrence.raw_key,
-            candidate_keys: occurrence.candidate_keys
+            candidate_keys: occurrence.candidate_keys,
+            plural: occurrence.plural
           )
         ]
       end

--- a/lib/i18n/tasks/scanners/occurrence_from_position.rb
+++ b/lib/i18n/tasks/scanners/occurrence_from_position.rb
@@ -11,7 +11,7 @@ module I18n
         # @param contents [String] contents of the file at the path.
         # @param position [Integer] position just before the beginning of the match.
         # @return [Results::Occurrence]
-        def occurrence_from_position(path, contents, position, raw_key: nil, candidate_keys: nil)
+        def occurrence_from_position(path, contents, position, raw_key: nil, candidate_keys: nil, plural: nil)
           line_begin = contents.rindex(/^/, position - 1)
           line_end = contents.index(/.(?=\r?\n|$)/, position)
           Results::Occurrence.new(
@@ -21,7 +21,8 @@ module I18n
             line_pos: position - line_begin + 1,
             line: contents[line_begin..line_end],
             raw_key: raw_key,
-            candidate_keys: candidate_keys
+            candidate_keys: candidate_keys,
+            plural: plural
           )
         end
       end

--- a/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
@@ -118,6 +118,11 @@ module I18n::Tasks::Scanners::PrismScanners
       )
     end
 
+    # @return [Boolean] whether this call passes a `count:` argument, indicating plural usage.
+    def plural?
+      @options.key?("count")
+    end
+
     def occurrences(file_path)
       occurrence(file_path)
     end
@@ -196,7 +201,8 @@ module I18n::Tasks::Scanners::PrismScanners
         line_pos: location.start_column,
         line_num: location.start_line,
         raw_key: key,
-        candidate_keys: Array(final)
+        candidate_keys: Array(final),
+        plural: plural?
       )
 
       # full_key may be a single String or an Array of candidate strings

--- a/lib/i18n/tasks/scanners/results/occurrence.rb
+++ b/lib/i18n/tasks/scanners/results/occurrence.rb
@@ -31,6 +31,12 @@ module I18n::Tasks
         # @return [Array<String>, nil] candidate keys that may be used at runtime
         attr_reader :candidate_keys
 
+        # @return [Boolean, nil] whether this key was used with a `count:` argument (plural usage).
+        #   `true`  - explicitly used as plural (Prism scanner detected `count:`)
+        #   `false` - explicitly used without `count:` (Prism scanner, no count)
+        #   `nil`   - unknown (e.g., from a non-Prism scanner that doesn't track this)
+        attr_reader :plural
+
         # @param path        [String]
         # @param pos         [Integer]
         # @param line_num    [Integer]
@@ -38,8 +44,9 @@ module I18n::Tasks
         # @param line        [String]
         # @param raw_key     [String, nil]
         # @param default_arg [String, nil]
+        # @param plural      [Boolean, nil]
         # rubocop:disable Metrics/ParameterLists
-        def initialize(path:, pos:, line_num:, line_pos:, line:, raw_key: nil, default_arg: nil, candidate_keys: nil)
+        def initialize(path:, pos:, line_num:, line_pos:, line:, raw_key: nil, default_arg: nil, candidate_keys: nil, plural: nil)
           @path = path
           @pos = pos
           @line_num = line_num
@@ -48,6 +55,7 @@ module I18n::Tasks
           @raw_key = raw_key
           @default_arg = default_arg
           @candidate_keys = candidate_keys
+          @plural = plural
         end
         # rubocop:enable Metrics/ParameterLists
 

--- a/spec/missing_keys_spec.rb
+++ b/spec/missing_keys_spec.rb
@@ -96,4 +96,95 @@ RSpec.describe "MissingKeys" do
       expect(missing.leaves.to_a).to be_empty
     end
   end
+
+  describe "plural detection from scanner" do
+    let(:i18n) { I18n::Tasks::BaseTask.new }
+    let(:plural_config) do
+      {
+        en: {
+          i18n: {
+            plural: {
+              keys: %i[one other],
+              rule: -> {}
+            }
+          }
+        }
+      }
+    end
+    let(:locale_data_with_partial_plural) do
+      {"en" => {"en" => {"foo" => {"one" => "One"}}}}
+    end
+
+    before do
+      allow(i18n).to receive_messages(load_rails_i18n_pluralization!: plural_config, external_key?: false, ignore_key?: false)
+      allow(i18n).to receive(:data) do
+        double("data").tap do |d| # rubocop:disable RSpec/VerifiedDoubles
+          allow(d).to receive(:[]) do |locale|
+            ::I18n::Tasks::Data::Tree::Siblings.from_nested_hash(
+              locale_data_with_partial_plural[locale] || {}
+            )
+          end
+        end
+      end
+    end
+
+    def make_plural_source_map(key, plural_value)
+      occ = ::I18n::Tasks::Scanners::Results::Occurrence.new(
+        path: "app/views/example.html.erb",
+        line: "t('#{key}')",
+        pos: 0, line_pos: 0, line_num: 1,
+        raw_key: key,
+        plural: plural_value
+      )
+      {key => [occ]}
+    end
+
+    context "when a key is used only without count: (Prism scanner, plural: false)" do
+      it "does not report missing plural forms" do
+        allow(i18n).to receive(:source_key_occurrences_map).and_return(make_plural_source_map("foo", false))
+
+        missing = i18n.missing_plural_forest(%w[en])
+        expect(missing.leaves.to_a).to be_empty
+      end
+    end
+
+    context "when a key is used with count: (Prism scanner, plural: true)" do
+      it "reports missing plural forms" do
+        allow(i18n).to receive(:source_key_occurrences_map).and_return(make_plural_source_map("foo", true))
+
+        missing = i18n.missing_plural_forest(%w[en])
+        missing_keys = missing.leaves.map { |l| l.full_key(root: false) }
+        expect(missing_keys).to include("foo")
+      end
+    end
+
+    context "when a key is not in the source and Prism is active" do
+      it "does not report missing plural forms (Prism would have detected count: usage)" do
+        allow(i18n).to receive_messages(source_key_occurrences_map: {}, prism_scanner_active?: true)
+
+        missing = i18n.missing_plural_forest(%w[en])
+        expect(missing.leaves.to_a).to be_empty
+      end
+    end
+
+    context "when a key is not in the source and Prism is not active" do
+      it "still reports missing plural forms (backward-compatible behavior)" do
+        allow(i18n).to receive_messages(source_key_occurrences_map: {}, prism_scanner_active?: false)
+
+        missing = i18n.missing_plural_forest(%w[en])
+        missing_keys = missing.leaves.map { |l| l.full_key(root: false) }
+        expect(missing_keys).to include("foo")
+      end
+    end
+
+    context "when scanner produces nil plural (non-Prism scanner)" do
+      it "still reports missing plural forms (backward-compatible behavior)" do
+        allow(i18n).to receive(:source_key_occurrences_map).and_return(make_plural_source_map("foo", nil))
+
+        missing = i18n.missing_plural_forest(%w[en])
+        missing_keys = missing.leaves.map { |l| l.full_key(root: false) }
+        expect(missing_keys).to include("foo")
+      end
+    end
+  end
 end

--- a/spec/missing_keys_spec.rb
+++ b/spec/missing_keys_spec.rb
@@ -158,18 +158,9 @@ RSpec.describe "MissingKeys" do
       end
     end
 
-    context "when a key is not in the source and Prism is active" do
-      it "does not report missing plural forms (Prism would have detected count: usage)" do
-        allow(i18n).to receive_messages(source_key_occurrences_map: {}, prism_scanner_active?: true)
-
-        missing = i18n.missing_plural_forest(%w[en])
-        expect(missing.leaves.to_a).to be_empty
-      end
-    end
-
-    context "when a key is not in the source and Prism is not active" do
-      it "still reports missing plural forms (backward-compatible behavior)" do
-        allow(i18n).to receive_messages(source_key_occurrences_map: {}, prism_scanner_active?: false)
+    context "when a key is not in the source" do
+      it "still reports missing plural forms (conservative: absent keys are always checked)" do
+        allow(i18n).to receive(:source_key_occurrences_map).and_return({})
 
         missing = i18n.missing_plural_forest(%w[en])
         missing_keys = missing.leaves.map { |l| l.full_key(root: false) }

--- a/spec/plural_detection_prism_real_app_spec.rb
+++ b/spec/plural_detection_prism_real_app_spec.rb
@@ -1,0 +1,354 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Real-app integration tests for Prism-based plural detection.
+#
+# Each scenario mirrors an issue report and shows the expected behaviour when
+# the Prism scanner is (or is not) active.
+#
+# Issues covered:
+#   #473 – defining `one` / `other` reported as missing even when not used as plural
+#   #270 – dynamic + plural key: plural forms appear unused (documented limitation)
+#   #516 – `other` sub-key causes unused false-positive (documented limitation)
+#   #600 – Arabic: only `one`/`other` defined but locale requires more forms
+#   #705 – Polish: `one`, `few`, `many` defined but `other` reported missing
+RSpec.describe "Plural detection with Prism scanner – real app examples" do
+  # Create a BaseTask whose scanner uses Prism and looks in the given paths.
+  def prism_task(paths:)
+    t = I18n::Tasks::BaseTask.new
+    t.config[:search] = {paths: Array(paths), prism: "rails"}
+    t
+  end
+
+  # Create a BaseTask with the legacy (non-Prism) scanner for comparison.
+  def legacy_task(paths:)
+    I18n::Tasks::BaseTask.new.tap do |t|
+      t.config[:search] = {paths: Array(paths)}
+    end
+  end
+
+  def missing_plural_keys(task, locales)
+    task.missing_plural_forest(locales).leaves.map { |l| l.full_key(root: false) }
+  end
+
+  def unused_key_names(task, locale: nil)
+    tree = locale ? task.unused_tree(locale: locale) : task.unused_keys
+    tree.leaves.map { |l| l.full_key(root: false) }
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #473 – defining `one` (or any plural form) is detected as missing
+  # keys even when the translation is never called with count:.
+  #
+  # Reproduction: a key like `document_count: { one: "1 document" }` has an
+  # incomplete plural structure, but the code only calls
+  # `t('document_count', title: @doc.title)` (no count:).  The old scanner
+  # reported `other` as missing; with Prism we can see there is no plural call.
+  # ---------------------------------------------------------------------------
+  describe "Issue #473 – partial plural definition used WITHOUT count:" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "document_count" => {"one" => "1 document"}   # missing "other"
+        }}.to_yaml,
+        "app/controllers/documents_controller.rb" => <<~RUBY
+          class DocumentsController < ApplicationController
+            def show
+              # Used without count: – this is NOT a plural call
+              @label = t('document_count', title: @document.title)
+            end
+          end
+        RUBY
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "does NOT report missing plural forms when Prism sees no count: argument" do
+      task = prism_task(paths: ["app/controllers/documents_controller.rb"])
+      expect(missing_plural_keys(task, ["en"])).not_to include("document_count")
+    end
+
+    it "DOES report missing plural forms with the legacy scanner (backward-compatible)" do
+      task = legacy_task(paths: ["app/controllers/documents_controller.rb"])
+      expect(missing_plural_keys(task, ["en"])).to include("document_count")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #473 – cross-locale variant.
+  # Japanese pluralization only requires the `other` key (rails-i18n).
+  # A Japanese locale with `notification: { one: "通知" }` triggers a false
+  # positive because `one` looks like a plural suffix even though the code
+  # never passes count:.
+  # ---------------------------------------------------------------------------
+  describe "Issue #473 – cross-locale: Japanese partial plural used WITHOUT count:" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "notification" => {"one" => "1 notification", "other" => "%{count} notifications"}
+        }}.to_yaml,
+        "config/locales/ja.yml" => {"ja" => {
+          "notification" => {"one" => "通知"}  # Japanese needs `other`, not `one`
+        }}.to_yaml,
+        "app/views/notifications/index.html.erb" => <<~ERB
+          <p><%= t('notification') %></p>
+        ERB
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "does NOT report missing `other` for ja when Prism sees no count: in ERB" do
+      task = prism_task(paths: ["app/views/notifications/index.html.erb"])
+      expect(missing_plural_keys(task, ["ja"])).not_to include("notification")
+    end
+
+    it "DOES report missing `other` for ja with the legacy scanner" do
+      task = legacy_task(paths: ["app/views/notifications/index.html.erb"])
+      expect(missing_plural_keys(task, ["ja"])).to include("notification")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #473 – mixed usage: the same key is called BOTH with and without
+  # count: in different places.  We must still report missing plural forms
+  # because at least one call is a genuine plural invocation.
+  # ---------------------------------------------------------------------------
+  describe "Issue #473 – mixed usage: key called with AND without count:" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "item_count" => {"one" => "1 item"}  # missing "other"
+        }}.to_yaml,
+        "app/controllers/items_controller.rb" => <<~RUBY
+          class ItemsController < ApplicationController
+            def index
+              @plural_label = t('item_count', count: @items.size)  # plural call
+              @singular_label = t('item_count')                    # non-plural call
+            end
+          end
+        RUBY
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "DOES report missing plural forms when at least one call uses count:" do
+      task = prism_task(paths: ["app/controllers/items_controller.rb"])
+      expect(missing_plural_keys(task, ["en"])).to include("item_count")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #600 – Arabic locale: user deliberately defines only `one` and
+  # `other` (because their translation tool, e.g. Weblate, does not support
+  # the full Arabic plural set).  When the key IS called with count:, it is
+  # correct for i18n-tasks to report the missing forms.
+  #
+  # This test documents the CURRENT (correct) behaviour: Prism detects the
+  # plural call and still flags zero/two/few/many as missing.
+  # ---------------------------------------------------------------------------
+  describe "Issue #600 – Arabic locale with incomplete plural set used WITH count:" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "documents_found" => {"one" => "1 document found", "other" => "%{count} documents found"}
+        }}.to_yaml,
+        "config/locales/ar.yml" => {"ar" => {
+          # Weblate limitation: only one + other defined
+          "documents_found" => {"one" => "وُجد مستند واحد", "other" => "وُجدت %{count} مستندات"}
+          # Arabic requires: zero, one, two, few, many, other
+        }}.to_yaml,
+        "app/views/search/results.html.erb" => <<~ERB
+          <p><%= t('documents_found', count: @results.size) %></p>
+        ERB
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "correctly reports zero/two/few/many as missing for Arabic when count: is used" do
+      task = prism_task(paths: ["app/views/search/results.html.erb"])
+      missing = missing_plural_keys(task, ["ar"])
+      # Arabic requires zero, one, two, few, many, other — only one+other defined
+      expect(missing).to include("documents_found")
+    end
+
+    it "does NOT report missing plural forms if the key is NOT called with count:" do
+      # If the call has no count: (e.g. a bug, but Prism can detect it),
+      # the plural check is suppressed — there is no plural invocation.
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "documents_found" => {"one" => "1 document", "other" => "%{count} documents"}
+        }}.to_yaml,
+        "config/locales/ar.yml" => {"ar" => {
+          "documents_found" => {"one" => "واحد", "other" => "عدة"}
+        }}.to_yaml,
+        "app/views/search/results.html.erb" => <<~ERB
+          <p><%= t('documents_found') %></p>
+        ERB
+      )
+      task = prism_task(paths: ["app/views/search/results.html.erb"])
+      expect(missing_plural_keys(task, ["ar"])).not_to include("documents_found")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #705 – Polish locale: `one`, `few`, and `many` are defined, but
+  # `other` is not.  Polish pluralization requires all four keys (one, few,
+  # many, other).  When the key is called with count:, `other` is correctly
+  # flagged as missing.
+  #
+  # This test documents the CURRENT (correct) behaviour.  The issue asks for
+  # `other` to not be required when `few` and `many` are present, which is a
+  # separate rails-i18n rules concern beyond Prism detection.
+  # ---------------------------------------------------------------------------
+  describe "Issue #705 – Polish locale: one/few/many defined, other missing, used WITH count:" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "invoice" => {"one" => "Invoice", "other" => "Invoices"}
+        }}.to_yaml,
+        "config/locales/pl.yml" => {"pl" => {
+          # Polish user intentionally omits `other` (rare, always shadowed by few/many)
+          "invoice" => {"one" => "Faktura", "few" => "Faktury", "many" => "Faktur"}
+        }}.to_yaml,
+        "app/views/invoices/index.html.erb" => <<~ERB
+          <h1><%= t('invoice', count: @invoices.size) %></h1>
+        ERB
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "reports `other` as missing for Polish when count: is used (correct behaviour)" do
+      task = prism_task(paths: ["app/views/invoices/index.html.erb"])
+      expect(missing_plural_keys(task, ["pl"])).to include("invoice")
+    end
+
+    it "does NOT report missing `other` for Polish when key is NOT called with count:" do
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "invoice" => {"one" => "Invoice", "other" => "Invoices"}
+        }}.to_yaml,
+        "config/locales/pl.yml" => {"pl" => {
+          "invoice" => {"one" => "Faktura", "few" => "Faktury", "many" => "Faktur"}
+        }}.to_yaml,
+        "app/views/invoices/index.html.erb" => <<~ERB
+          <h1><%= t('invoice') %></h1>
+        ERB
+      )
+      task = prism_task(paths: ["app/views/invoices/index.html.erb"])
+      expect(missing_plural_keys(task, ["pl"])).not_to include("invoice")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #270 – dynamic key expression with count: (documented limitation).
+  #
+  # When the translation call uses a dynamic key (string interpolation), Prism
+  # cannot resolve which specific key is being looked up.  The plural sub-keys
+  # for that prefix will appear unused because they are not statically
+  # reachable.  This is a known limitation of static analysis.
+  # ---------------------------------------------------------------------------
+  describe "Issue #270 – dynamic key + count: (documented limitation)" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          "filters" => {
+            "by" => {
+              "active" => {"one" => "1 active filter", "other" => "%{count} active filters"},
+              "inactive" => {"one" => "1 inactive filter", "other" => "%{count} inactive filters"}
+            }
+          }
+        }}.to_yaml,
+        "app/views/filters/index.html.erb" => <<~ERB
+          <%# Dynamic key: Prism cannot resolve the specific plural key %>
+          <p><%= t("filters.by.\#{filter_type}", count: @items.size) %></p>
+        ERB
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "does NOT detect specific plural keys used through a dynamic expression (known limitation)" do
+      task = prism_task(paths: ["app/views/filters/index.html.erb"])
+      used = task.used_tree(strict: true).leaves.map { |l| l.full_key(root: false) }
+      # Prism excludes dynamic keys in strict mode – the individual plural sub-keys
+      # are not visible to the scanner, so they will appear unused.
+      expect(used).not_to include("filters.by.active")
+      expect(used).not_to include("filters.by.inactive")
+    end
+
+    it "reports filters.by.active / filters.by.inactive as unused (expected limitation)" do
+      task = prism_task(paths: ["app/views/filters/index.html.erb"])
+      unused = unused_key_names(task, locale: "en")
+      # Without locale prefix — both collapse to the key name without locale root
+      expect(unused).to include("filters.by.active")
+      expect(unused).to include("filters.by.inactive")
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Issue #516 – `other` sub-key in a non-plural translation causes an unused
+  # false positive (documented limitation for unused_keys).
+  #
+  # When a locale has `preferences: { other: "Eile" }` and the base locale has
+  # both `other` AND non-plural siblings, the locale-only `{ other: ... }`
+  # looks like a collapsed plural node.  The unused-keys check depluraises it
+  # to `preferences` which is not in the used-keys tree (the code uses
+  # `preferences.posting_defaults`, not `preferences` itself).
+  #
+  # Note: `missing_plural_forest` is NOT affected for the base locale because
+  # `plural_forms?` returns false when non-plural siblings are present.
+  # The Prism plural detection helps for the base locale case only.
+  # ---------------------------------------------------------------------------
+  describe "Issue #516 – `other` sub-key in non-plural translation" do
+    around do |ex|
+      TestCodebase.setup(
+        "config/locales/en.yml" => {"en" => {
+          # `other` exists alongside a non-plural sibling – not a plural node
+          "preferences" => {"other" => "Other", "posting_defaults" => "Posting defaults"}
+        }}.to_yaml,
+        "config/locales/ga.yml" => {"ga" => {
+          # Irish locale only has `other` – looks like a collapsed plural node
+          "preferences" => {"other" => "Eile"}
+        }}.to_yaml,
+        "app/controllers/preferences_controller.rb" => <<~RUBY
+          class PreferencesController < ApplicationController
+            def show
+              @label = t('preferences.posting_defaults')
+            end
+          end
+        RUBY
+      )
+      TestCodebase.in_test_app_dir { ex.run }
+    ensure
+      TestCodebase.teardown
+    end
+
+    it "does NOT flag `en.preferences` as needing plural forms (non-plural siblings present)" do
+      # English has both `other` and `posting_defaults` → not a plural node →
+      # missing_plural_forest does not inspect it at all.
+      task = prism_task(paths: ["app/controllers/preferences_controller.rb"])
+      expect(missing_plural_keys(task, ["en"])).not_to include("preferences")
+    end
+
+    it "flags `ga.preferences` as unused because it looks like a collapsed plural (known limitation)" do
+      # Irish only has `{ other: "Eile" }` → plural_forms? returns true →
+      # depluralize_key collapses it to `preferences` → `preferences` is not
+      # in the used tree (only `preferences.posting_defaults` is) → flagged unused.
+      task = prism_task(paths: ["app/controllers/preferences_controller.rb"])
+      ga_unused = unused_key_names(task, locale: "ga")
+      expect(ga_unused).to include("preferences")
+    end
+  end
+end

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-RSpec.describe "PrismScanner" do
+RSpec.describe "RubyScanner with Prism" do
   describe "controllers" do
     it "detects controller" do
       source = <<~RUBY
@@ -782,6 +782,56 @@ RSpec.describe "PrismScanner" do
           absolute_key
         ]
       )
+    end
+  end
+
+  describe "plural detection" do
+    it "marks occurrence as plural when count: is passed" do
+      source = <<~RUBY
+        t('my_key', count: n)
+      RUBY
+
+      occurrences = process_string("app/views/example.html.erb", source)
+      expect(occurrences).not_to be_empty
+      key, occ = occurrences.first
+      expect(key).to eq("my_key")
+      expect(occ.plural).to be(true)
+    end
+
+    it "marks occurrence as non-plural when count: is not passed" do
+      source = <<~RUBY
+        t('my_key')
+      RUBY
+
+      occurrences = process_string("app/views/example.html.erb", source)
+      expect(occurrences).not_to be_empty
+      key, occ = occurrences.first
+      expect(key).to eq("my_key")
+      expect(occ.plural).to be(false)
+    end
+
+    it "marks occurrence as plural when count: is a variable" do
+      source = <<~RUBY
+        t('my_key', count: @count)
+      RUBY
+
+      occurrences = process_string("app/views/example.html.erb", source)
+      expect(occurrences).not_to be_empty
+      key, occ = occurrences.first
+      expect(key).to eq("my_key")
+      expect(occ.plural).to be(true)
+    end
+
+    it "marks occurrence as plural when count: is an integer" do
+      source = <<~RUBY
+        t('my_key', count: 5)
+      RUBY
+
+      occurrences = process_string("app/views/example.html.erb", source)
+      expect(occurrences).not_to be_empty
+      key, occ = occurrences.first
+      expect(key).to eq("my_key")
+      expect(occ.plural).to be(true)
     end
   end
 


### PR DESCRIPTION
- Instead of checking for plural keys in the translation, we can check
  for plural usage in the code and then raise warnings.
