### PR TITLE
Add --keep-order (-k) to the prune command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - `check-prism` makes better comparison between parsers for candidate keys.
 - `ignore_missing` now supports per-locale syntax (just like `ignore_eq_base`), allowing you to ignore different keys for different locales. Backward compatible with the array syntax.
 - Prism now supports ViewComponents and its relative translations.
+- `prune` now supports `-k` / `--keep-order` to preserve the original key ordering in locale files, consistent with `remove-unused`. Also documents the `prune` command in the README.
 
 ## v1.1.2
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ These tasks can infer [dynamic keys](#dynamic-keys) such as `t("category.\#{cate
 If you want to keep the ordering from the original language file when using remove-unused, pass
 `-k` or `--keep-order`.
 
+### Prune keys not in base locale
+
+Remove keys from non-base locales that are absent in the base locale:
+
+```bash
+$ i18n-tasks prune
+```
+
+Pass `-k` or `--keep-order` to preserve the original key ordering in the locale files.
+
 ### Normalize data
 
 Sort the keys:

--- a/lib/i18n/tasks/command/commands/prune.rb
+++ b/lib/i18n/tasks/command/commands/prune.rb
@@ -4,7 +4,12 @@ module I18n::Tasks
       module Prune
         include ::I18n::Tasks::Command::Collection
 
-        cmd :prune, desc: t("i18n_tasks.cmd.desc.prune"), args: %i[confirm]
+        arg :keep_order,
+          "-k",
+          "--keep-order",
+          t("i18n_tasks.cmd.args.desc.keep_order")
+
+        cmd :prune, desc: t("i18n_tasks.cmd.desc.prune"), args: %i[confirm keep_order]
         def prune(opts = {})
           diff_forest = i18n.prunable_keys(
             base_locale: i18n.base_locale,
@@ -29,6 +34,7 @@ module I18n::Tasks
           end
           print_success(t("i18n_tasks.prune.pruned", count:, locales: locales.join(", ")))
 
+          i18n.data.config = i18n.data.config.merge(sort: false) if opts[:"keep-order"]
           i18n.data.remove_by_key!(diff_forest)
         end
 

--- a/spec/commands/prune_commands_spec.rb
+++ b/spec/commands/prune_commands_spec.rb
@@ -50,4 +50,45 @@ RSpec.describe "Prune commands" do
     expect(YAML.load_file("config/locales/de.yml")).to eq("de" => locale_data["de"])
     expect(YAML.load_file("config/locales/es.yml")).to eq("es" => locale_data["es"])
   end
+
+  it "prunes keys with --keep-order" do
+    run_cmd("prune", "--confirm", "--keep-order")
+
+    expect(YAML.load_file("config/locales/fr.yml")["fr"]).not_to have_key("fr_de")
+    expect(YAML.load_file("config/locales/de.yml")["de"]).not_to have_key("fr_de")
+    expect(YAML.load_file("config/locales/fr.yml")["fr"]).to have_key("hello")
+    expect(YAML.load_file("config/locales/de.yml")["de"]).to have_key("hello")
+  end
+
+  context "with keys in non-alphabetical order" do
+    let(:locale_data) do
+      {
+        "en" => {
+          "zebra" => "Zebra",
+          "apple" => "Apple",
+          "mango" => "Mango"
+        },
+        "fr" => {
+          "zebra" => "Zèbre",
+          "apple" => "Pomme",
+          "mango" => "Mangue",
+          "fr_only" => "French only"
+        }
+      }
+    end
+
+    let(:config) { {base_locale: "en", locales: %w[en fr]} }
+
+    it "preserves key order with --keep-order" do
+      task = TestCodebase.i18n_task
+      initial_keys = task.data["fr"]["fr"].children.map(&:key).reject { |k| k == "fr_only" }
+
+      run_cmd("prune", "--confirm", "--keep-order")
+
+      task.data.reload
+      final_keys = task.data["fr"]["fr"].children.map(&:key)
+
+      expect(final_keys).to eq(initial_keys)
+    end
+  end
 end


### PR DESCRIPTION
The prune command removes keys from non-base locales that are absent
in the base locale. Like remove-unused, it rewrites locale files and
was silently sorting keys in the process.

Add -k / --keep-order to prune, mirroring the flag already available
on remove-unused (added in #297). When passed, the data layer writes
files with sort: false, preserving the original key ordering.

Also documents the prune command in README.md, which previously had
no mention of it.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
