### PR TITLE
Add performance benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tmp
 .ruby-gemset
 .tool-versions
 *~
+
+# Generated benchmark fixtures (large, derived — regenerated on first run)
+/benchmarks/fixtures/generated/

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,11 @@ gem "rubocop-rspec", require: false
 gem "simplecov"
 gem "yard"
 
+group :bench do
+  gem "benchmark-ips", require: false
+  gem "memory_profiler", require: false
+end
+
 # Translation backends
 # These are only used in tests
 gem "deepl-rb", ">= 2.1.0"

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
-require "benchmark/ips"
-require "memory_profiler"
+require "fileutils"
+
+begin
+  require "benchmark/ips"
+  require "memory_profiler"
+rescue LoadError => e
+  warn "#{e.message}\n\nBenchmark gems are missing. Install them with:\n\n  bundle install\n\n" \
+       "If you have BUNDLE_WITHOUT set, make sure it does not exclude the :bench group.\n"
+  exit 1
+end
 
 # Load the gem under test
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
@@ -118,6 +126,3 @@ module BenchHelper
     end
   end
 end
-
-# Pre-generate fixtures on first require
-BenchmarkFixtures.generate_all

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "benchmark/ips"
+require "memory_profiler"
+
+# Load the gem under test
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "i18n/tasks"
+
+require_relative "fixtures/generator"
+
+BENCH_ROOT = File.expand_path("..", __dir__)
+
+module BenchHelper
+  # Generate all fixture scales (idempotent - reads from cache unless forced).
+  def self.prepare_fixtures(force: false)
+    BenchmarkFixtures.generate_all(force: force)
+  end
+
+  # Build a configured I18n::Tasks::BaseTask context pointed at a fixture directory.
+  #
+  # @param scale [:small, :medium, :large]
+  # @return [I18n::Tasks::BaseTask]
+  def self.build_context(scale)
+    dir = BenchmarkFixtures.generate(scale)
+    config_file = File.join(dir, "config", "i18n-tasks.yml")
+    Dir.chdir(dir) do
+      I18n::Tasks::BaseTask.new(config_file: config_file)
+    end
+  end
+
+  # Run a block with working directory set to the fixture dir.
+  # The context is created fresh each time so memoized caches don't carry over.
+  def self.in_fixture_dir(scale)
+    dir = BenchmarkFixtures.generate(scale)
+    Dir.chdir(dir) { yield }
+  end
+
+  # Pre-warm the context so file-system caches are hot before timing.
+  def self.warm_context(context)
+    context.used_tree
+    context
+  rescue
+    context
+  end
+
+  # Print a section header.
+  def self.header(title)
+    puts
+    puts "=" * 60
+    puts "  #{title}"
+    puts "=" * 60
+    puts
+  end
+
+  # Save IPS results to a JSON file for baseline comparison.
+  #
+  # @param suite [Benchmark::IPS::Suite] the completed suite
+  # @param label [String] top-level key in the JSON object
+  # @param path [String] path to the results JSON file
+  def self.save_results(suite, label, path: File.join(BENCH_ROOT, "benchmarks", "results", "baseline.json"))
+    require "json"
+    FileUtils.mkdir_p(File.dirname(path))
+    existing = File.exist?(path) ? JSON.parse(File.read(path)) : {}
+    existing[label] ||= {}
+    suite.entries.each do |entry|
+      existing[label][entry.label] = {
+        ips: entry.stats.central_tendency.round(2),
+        ips_sd: entry.stats.error.round(2),
+        microseconds: (1_000_000.0 / entry.stats.central_tendency).round(2)
+      }
+    end
+    File.write(path, JSON.pretty_generate(existing))
+    puts "Results saved to #{path}"
+  end
+
+  # Compare an IPS suite against a stored baseline and warn about regressions.
+  #
+  # @param suite [Benchmark::IPS::Suite]
+  # @param label [String]
+  # @param threshold [Float] fraction below baseline that counts as a regression (default 0.10 = 10%)
+  # @param path [String] path to the baseline JSON file
+  # @return [Boolean] true if no regressions found
+  def self.compare_baseline(suite, label, threshold: 0.10,
+    path: File.join(BENCH_ROOT, "benchmarks", "results", "baseline.json"))
+    require "json"
+    return true unless File.exist?(path)
+
+    baseline = JSON.parse(File.read(path))
+    section = baseline[label]
+    return true unless section
+
+    regressions = []
+    suite.entries.each do |entry|
+      baseline_entry = section[entry.label]
+      next unless baseline_entry
+
+      baseline_ips = baseline_entry["ips"].to_f
+      next if baseline_ips.zero?
+
+      current_ips = entry.stats.central_tendency
+      ratio = current_ips / baseline_ips
+      if ratio < (1 - threshold)
+        regressions << format("  %-55s  %.1fx slower  (%.0f vs %.0f ips)",
+          entry.label, 1.0 / ratio, current_ips, baseline_ips)
+      end
+    end
+
+    if regressions.any?
+      puts
+      puts "⚠️  REGRESSIONS DETECTED (>#{(threshold * 100).to_i}% slowdown):"
+      regressions.each { |r| puts r }
+      puts
+      false
+    else
+      true
+    end
+  end
+end
+
+# Pre-generate fixtures on first require
+BenchmarkFixtures.generate_all

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -49,7 +49,8 @@ module BenchHelper
   def self.warm_context(context)
     context.used_tree
     context
-  rescue
+  rescue => e
+    warn "BenchHelper.warm_context failed: #{e.class}: #{e.message}"
     context
   end
 
@@ -117,7 +118,7 @@ module BenchHelper
 
     if regressions.any?
       puts
-      puts "⚠️  REGRESSIONS DETECTED (>#{(threshold * 100).to_i}% slowdown):"
+      puts "WARNING: REGRESSIONS DETECTED (>#{(threshold * 100).to_i}% slowdown):"
       regressions.each { |r| puts r }
       puts
       false

--- a/benchmarks/bench_helper.rb
+++ b/benchmarks/bench_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 require "bundler/setup"
 require "fileutils"
 
@@ -26,15 +27,19 @@ module BenchHelper
     BenchmarkFixtures.generate_all(force: force)
   end
 
-  # Build a configured I18n::Tasks::BaseTask context pointed at a fixture directory.
+  # Build a configured I18n::Tasks::BaseTask context pointed at a fixture directory
+  # and yield it within the correct working directory.
+  #
+  # i18n-tasks resolves relative search paths against the current working directory
+  # at scan time, so the task must be used within Dir.chdir(fixture_dir).
   #
   # @param scale [:small, :medium, :large]
-  # @return [I18n::Tasks::BaseTask]
+  # @yieldparam task [I18n::Tasks::BaseTask]
   def self.build_context(scale)
     dir = BenchmarkFixtures.generate(scale)
     config_file = File.join(dir, "config", "i18n-tasks.yml")
     Dir.chdir(dir) do
-      I18n::Tasks::BaseTask.new(config_file: config_file)
+      yield I18n::Tasks::BaseTask.new(config_file: config_file)
     end
   end
 
@@ -72,6 +77,7 @@ module BenchHelper
     require "json"
     FileUtils.mkdir_p(File.dirname(path))
     existing = File.exist?(path) ? JSON.parse(File.read(path)) : {}
+    existing["_env"] = environment_info
     existing[label] ||= {}
     suite.entries.each do |entry|
       existing[label][entry.label] = {
@@ -97,6 +103,18 @@ module BenchHelper
     return true unless File.exist?(path)
 
     baseline = JSON.parse(File.read(path))
+
+    if (saved_env = baseline["_env"])
+      current_env = environment_info
+      mismatches = current_env.filter_map do |key, val|
+        "#{key}: baseline=#{saved_env[key].inspect} current=#{val.inspect}" if saved_env[key] != val
+      end
+      if mismatches.any?
+        warn "WARNING: baseline environment differs from current — comparison may be unreliable:\n" \
+             "  #{mismatches.join("\n  ")}"
+      end
+    end
+
     section = baseline[label]
     return true unless section
 
@@ -125,5 +143,14 @@ module BenchHelper
     else
       true
     end
+  end
+
+  # Returns a hash of relevant environment metadata for baseline comparison.
+  def self.environment_info
+    {
+      "ruby_version" => RUBY_VERSION,
+      "ruby_platform" => RUBY_PLATFORM,
+      "ruby_engine" => RUBY_ENGINE
+    }
   end
 end

--- a/benchmarks/data_bench.rb
+++ b/benchmarks/data_bench.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+# Benchmarks for YAML data loading and writing (the I/O layer).
+#
+# Measures the cost of:
+# - Parsing YAML locale files into Ruby hashes
+# - Dumping Ruby hashes back to YAML strings
+# - Building Siblings trees from parsed YAML hashes
+# - The full data[locale] load path used by BaseTask
+#
+# Usage:
+#   bundle exec ruby benchmarks/data_bench.rb
+#   bundle exec ruby benchmarks/data_bench.rb --save
+#   bundle exec ruby benchmarks/data_bench.rb --compare
+
+require_relative "bench_helper"
+
+require "yaml"
+require "i18n/tasks/data/adapter/yaml_adapter"
+require "i18n/tasks/data/tree/siblings"
+
+SAVE_RESULTS = ARGV.include?("--save")
+COMPARE_RESULTS = ARGV.include?("--compare")
+
+Siblings = I18n::Tasks::Data::Tree::Siblings
+YamlAdapter = I18n::Tasks::Data::Adapter::YamlAdapter
+
+# Build YAML strings of various sizes in memory (no disk I/O during benchmarks)
+def yaml_string_for_scale(scale)
+  dir = BenchmarkFixtures.generate(scale)
+  File.read(File.join(dir, "config", "locales", "en.yml"))
+end
+
+SMALL_YAML = yaml_string_for_scale(:small).freeze
+MEDIUM_YAML = yaml_string_for_scale(:medium).freeze
+LARGE_YAML = yaml_string_for_scale(:large).freeze
+
+SMALL_HASH = YamlAdapter.parse(SMALL_YAML, nil).freeze
+MEDIUM_HASH = YamlAdapter.parse(MEDIUM_YAML, nil).freeze
+LARGE_HASH = YamlAdapter.parse(LARGE_YAML, nil).freeze
+
+SMALL_TREE = Siblings.from_nested_hash(SMALL_HASH).freeze
+MEDIUM_TREE = Siblings.from_nested_hash(MEDIUM_HASH).freeze
+
+# ---------------------------------------------------------------------------
+# YAML parse benchmarks
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("YAML parse (string → hash)")
+
+parse_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("YAML parse small  (~#{SMALL_YAML.size / 1024}KB)") do
+    YamlAdapter.parse(SMALL_YAML, nil)
+  end
+
+  x.report("YAML parse medium (~#{MEDIUM_YAML.size / 1024}KB)") do
+    YamlAdapter.parse(MEDIUM_YAML, nil)
+  end
+
+  x.report("YAML parse large  (~#{LARGE_YAML.size / 1024}KB)") do
+    YamlAdapter.parse(LARGE_YAML, nil)
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# YAML dump benchmarks
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("YAML dump (hash → string)")
+
+dump_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("YAML dump small  tree") do
+    YamlAdapter.dump(SMALL_HASH, nil)
+  end
+
+  x.report("YAML dump medium tree") do
+    YamlAdapter.dump(MEDIUM_HASH, nil)
+  end
+
+  x.report("YAML dump large  tree") do
+    YamlAdapter.dump(LARGE_HASH, nil)
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Hash → Siblings tree construction
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Hash → Siblings tree construction")
+
+load_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("from_nested_hash small") do
+    Siblings.from_nested_hash(SMALL_HASH)
+  end
+
+  x.report("from_nested_hash medium") do
+    Siblings.from_nested_hash(MEDIUM_HASH)
+  end
+
+  x.report("from_nested_hash large") do
+    Siblings.from_nested_hash(LARGE_HASH)
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Full data load via BaseTask
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Full data[locale] load via BaseTask")
+
+data_load_suite = Benchmark.ips do |x|
+  x.config(warmup: 2, time: 10)
+
+  [:small, :medium].each do |scale|
+    dir = BenchmarkFixtures.generate(scale)
+
+    x.report("data['en'] load (#{scale})") do
+      Dir.chdir(dir) do
+        task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+        task.data["en"]
+      end
+    end
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Memory profiles
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Memory — YAML parse + tree build (medium)")
+MemoryProfiler.report do
+  hash = YamlAdapter.parse(MEDIUM_YAML, nil)
+  Siblings.from_nested_hash(hash)
+end.pretty_print(scale_bytes: true, detailed_report: false)
+
+BenchHelper.header("Memory — YAML dump (medium)")
+MemoryProfiler.report { YamlAdapter.dump(MEDIUM_HASH, nil) }
+  .pretty_print(scale_bytes: true, detailed_report: false)
+
+if SAVE_RESULTS
+  BenchHelper.save_results(parse_suite, "data/yaml_parse")
+  BenchHelper.save_results(dump_suite, "data/yaml_dump")
+  BenchHelper.save_results(load_suite, "data/tree_load")
+  BenchHelper.save_results(data_load_suite, "data/full_load")
+end
+
+if COMPARE_RESULTS
+  BenchHelper.compare_baseline(parse_suite, "data/yaml_parse")
+  BenchHelper.compare_baseline(dump_suite, "data/yaml_dump")
+  BenchHelper.compare_baseline(load_suite, "data/tree_load")
+  BenchHelper.compare_baseline(data_load_suite, "data/full_load")
+end

--- a/benchmarks/data_bench.rb
+++ b/benchmarks/data_bench.rb
@@ -12,6 +12,7 @@
 #   bundle exec ruby benchmarks/data_bench.rb
 #   bundle exec ruby benchmarks/data_bench.rb --save
 #   bundle exec ruby benchmarks/data_bench.rb --compare
+#   bundle exec ruby benchmarks/data_bench.rb --memory  # include memory profiles
 
 require_relative "bench_helper"
 
@@ -21,6 +22,7 @@ require "i18n/tasks/data/tree/siblings"
 
 SAVE_RESULTS = ARGV.include?("--save")
 COMPARE_RESULTS = ARGV.include?("--compare")
+MEMORY_PROFILE = ARGV.include?("--memory")
 
 Siblings = I18n::Tasks::Data::Tree::Siblings
 YamlAdapter = I18n::Tasks::Data::Adapter::YamlAdapter
@@ -138,19 +140,22 @@ data_load_suite = Benchmark.ips do |x|
 end
 
 # ---------------------------------------------------------------------------
-# Memory profiles
+# Memory profiles (opt-in via --memory)
 # ---------------------------------------------------------------------------
 
-BenchHelper.header("Memory — YAML parse + tree build (medium)")
-MemoryProfiler.report do
-  hash = YamlAdapter.parse(MEDIUM_YAML, nil)
-  Siblings.from_nested_hash(hash)
-end.pretty_print(scale_bytes: true, detailed_report: false)
+if MEMORY_PROFILE
+  BenchHelper.header("Memory — YAML parse + tree build (medium)")
+  MemoryProfiler.report do
+    hash = YamlAdapter.parse(MEDIUM_YAML, nil)
+    Siblings.from_nested_hash(hash)
+  end.pretty_print(scale_bytes: true, detailed_report: false)
 
-BenchHelper.header("Memory — YAML dump (medium)")
-MemoryProfiler.report { YamlAdapter.dump(MEDIUM_HASH, nil) }
-  .pretty_print(scale_bytes: true, detailed_report: false)
+  BenchHelper.header("Memory — YAML dump (medium)")
+  MemoryProfiler.report { YamlAdapter.dump(MEDIUM_HASH, nil) }
+    .pretty_print(scale_bytes: true, detailed_report: false)
+end
 
+passed = true
 if SAVE_RESULTS
   BenchHelper.save_results(parse_suite, "data/yaml_parse")
   BenchHelper.save_results(dump_suite, "data/yaml_dump")
@@ -159,8 +164,10 @@ if SAVE_RESULTS
 end
 
 if COMPARE_RESULTS
-  BenchHelper.compare_baseline(parse_suite, "data/yaml_parse")
-  BenchHelper.compare_baseline(dump_suite, "data/yaml_dump")
-  BenchHelper.compare_baseline(load_suite, "data/tree_load")
-  BenchHelper.compare_baseline(data_load_suite, "data/full_load")
+  passed = false unless BenchHelper.compare_baseline(parse_suite, "data/yaml_parse")
+  passed = false unless BenchHelper.compare_baseline(dump_suite, "data/yaml_dump")
+  passed = false unless BenchHelper.compare_baseline(load_suite, "data/tree_load")
+  passed = false unless BenchHelper.compare_baseline(data_load_suite, "data/full_load")
 end
+
+exit(1) if COMPARE_RESULTS && !passed

--- a/benchmarks/end_to_end_bench.rb
+++ b/benchmarks/end_to_end_bench.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# End-to-end benchmarks for the full i18n-tasks pipeline.
+#
+# These measure the complete workflows that users actually run:
+#   - missing_keys: find translations present in base locale but missing elsewhere
+#   - unused_keys:  find keys defined in locale files but not used in source
+#   - used_tree:    scan all source files and build the usage tree
+#
+# These are the most important benchmarks for catching regressions — any change
+# to the scanner, data layer, or tree operations will show up here.
+#
+# Usage:
+#   bundle exec ruby benchmarks/end_to_end_bench.rb
+#   bundle exec ruby benchmarks/end_to_end_bench.rb --save    # save as new baseline
+#   bundle exec ruby benchmarks/end_to_end_bench.rb --compare # compare against baseline
+
+require_relative "bench_helper"
+
+SAVE_RESULTS = ARGV.include?("--save")
+COMPARE_RESULTS = ARGV.include?("--compare")
+
+all_suites = []
+
+# ---------------------------------------------------------------------------
+# Benchmark each pipeline operation across all scales
+# ---------------------------------------------------------------------------
+
+[:small, :medium, :large].each do |scale|
+  dir = BenchmarkFixtures.generate(scale)
+
+  BenchHelper.header("End-to-end pipeline — #{scale} fixture")
+
+  suite = Benchmark.ips do |x|
+    x.config(warmup: 2, time: 15)
+
+    x.report("used_tree     (#{scale})") do
+      Dir.chdir(dir) do
+        task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+        task.used_tree
+      end
+    end
+
+    x.report("missing_keys  (#{scale})") do
+      Dir.chdir(dir) do
+        task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+        task.missing_keys
+      end
+    end
+
+    x.report("unused_keys   (#{scale})") do
+      Dir.chdir(dir) do
+        task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+        task.unused_keys
+      end
+    end
+
+    x.compare!
+  end
+
+  all_suites << [suite, "end_to_end/#{scale}"]
+end
+
+# ---------------------------------------------------------------------------
+# Scanner backend comparison: parser AST vs Prism on medium fixture
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Scanner backend: parser AST vs Prism (medium used_tree)")
+
+dir = BenchmarkFixtures.generate(:medium)
+
+backend_suite = Benchmark.ips do |x|
+  x.config(warmup: 2, time: 15)
+
+  x.report("used_tree — parser AST (medium)") do
+    Dir.chdir(dir) do
+      task = I18n::Tasks::BaseTask.new(
+        config_file: File.join(dir, "config", "i18n-tasks.yml"),
+        search: {scanners: [["::I18n::Tasks::Scanners::RubyScanner", {only: %w[*.rb], prism: nil}],
+          ["::I18n::Tasks::Scanners::ErbAstScanner", {only: %w[*.erb]}]]}
+      )
+      task.used_tree
+    end
+  end
+
+  x.report("used_tree — prism (medium)") do
+    Dir.chdir(dir) do
+      task = I18n::Tasks::BaseTask.new(
+        config_file: File.join(dir, "config", "i18n-tasks.yml"),
+        search: {scanners: [["::I18n::Tasks::Scanners::RubyScanner", {only: %w[*.rb], prism: "rails"}],
+          ["::I18n::Tasks::Scanners::ErbAstScanner", {only: %w[*.erb]}]]}
+      )
+      task.used_tree
+    end
+  end
+
+  x.compare!
+end
+
+all_suites << [backend_suite, "end_to_end/backend_comparison"]
+
+# ---------------------------------------------------------------------------
+# Memory profiling on the most realistic scale (medium)
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Memory profile — missing_keys (medium)")
+dir = BenchmarkFixtures.generate(:medium)
+MemoryProfiler.report do
+  Dir.chdir(dir) do
+    task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+    task.missing_keys
+  end
+end.pretty_print(scale_bytes: true, detailed_report: false)
+
+BenchHelper.header("Memory profile — unused_keys (medium)")
+MemoryProfiler.report do
+  Dir.chdir(dir) do
+    task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+    task.unused_keys
+  end
+end.pretty_print(scale_bytes: true, detailed_report: false)
+
+# ---------------------------------------------------------------------------
+# Save / compare results
+# ---------------------------------------------------------------------------
+
+all_suites.each do |(suite, label)|
+  BenchHelper.save_results(suite, label) if SAVE_RESULTS
+  BenchHelper.compare_baseline(suite, label) if COMPARE_RESULTS
+end

--- a/benchmarks/end_to_end_bench.rb
+++ b/benchmarks/end_to_end_bench.rb
@@ -14,11 +14,13 @@
 #   bundle exec ruby benchmarks/end_to_end_bench.rb
 #   bundle exec ruby benchmarks/end_to_end_bench.rb --save    # save as new baseline
 #   bundle exec ruby benchmarks/end_to_end_bench.rb --compare # compare against baseline
+#   bundle exec ruby benchmarks/end_to_end_bench.rb --memory  # include memory profiles
 
 require_relative "bench_helper"
 
 SAVE_RESULTS = ARGV.include?("--save")
 COMPARE_RESULTS = ARGV.include?("--compare")
+MEMORY_PROFILE = ARGV.include?("--memory")
 
 all_suites = []
 
@@ -100,31 +102,37 @@ end
 all_suites << [backend_suite, "end_to_end/backend_comparison"]
 
 # ---------------------------------------------------------------------------
-# Memory profiling on the most realistic scale (medium)
+# Memory profiling on the most realistic scale (medium, opt-in via --memory)
 # ---------------------------------------------------------------------------
 
-BenchHelper.header("Memory profile — missing_keys (medium)")
-dir = BenchmarkFixtures.generate(:medium)
-MemoryProfiler.report do
-  Dir.chdir(dir) do
-    task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
-    task.missing_keys
-  end
-end.pretty_print(scale_bytes: true, detailed_report: false)
+if MEMORY_PROFILE
+  dir = BenchmarkFixtures.generate(:medium)
 
-BenchHelper.header("Memory profile — unused_keys (medium)")
-MemoryProfiler.report do
-  Dir.chdir(dir) do
-    task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
-    task.unused_keys
-  end
-end.pretty_print(scale_bytes: true, detailed_report: false)
+  BenchHelper.header("Memory profile — missing_keys (medium)")
+  MemoryProfiler.report do
+    Dir.chdir(dir) do
+      task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+      task.missing_keys
+    end
+  end.pretty_print(scale_bytes: true, detailed_report: false)
+
+  BenchHelper.header("Memory profile — unused_keys (medium)")
+  MemoryProfiler.report do
+    Dir.chdir(dir) do
+      task = I18n::Tasks::BaseTask.new(config_file: File.join(dir, "config", "i18n-tasks.yml"))
+      task.unused_keys
+    end
+  end.pretty_print(scale_bytes: true, detailed_report: false)
+end
 
 # ---------------------------------------------------------------------------
 # Save / compare results
 # ---------------------------------------------------------------------------
 
+passed = true
 all_suites.each do |(suite, label)|
   BenchHelper.save_results(suite, label) if SAVE_RESULTS
-  BenchHelper.compare_baseline(suite, label) if COMPARE_RESULTS
+  passed = false if COMPARE_RESULTS && !BenchHelper.compare_baseline(suite, label)
 end
+
+exit(1) if COMPARE_RESULTS && !passed

--- a/benchmarks/fixtures/generator.rb
+++ b/benchmarks/fixtures/generator.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "yaml"
+
+# Generates synthetic but realistic i18n-tasks fixtures at three scales.
+#
+# Each scale produces:
+#   - config/locales/<locale>.yml for each locale
+#   - app/controllers/*.rb with I18n.t() calls
+#   - app/views/**/*.html.erb with t() calls (relative and absolute)
+#   - app/helpers/*.rb with mixed calls
+#
+# ~10% of keys in base locale are intentionally left out of other locales (missing).
+# ~10% of defined keys are never referenced in source (unused).
+module BenchmarkFixtures
+  SCALES = {
+    small: {num_keys: 200, num_rb_files: 15, num_erb_files: 15, num_locales: 2},
+    medium: {num_keys: 2_000, num_rb_files: 100, num_erb_files: 100, num_locales: 5},
+    large: {num_keys: 8_000, num_rb_files: 300, num_erb_files: 300, num_locales: 8}
+  }.freeze
+
+  LOCALES = %w[en es fr de ja zh pt it ko nl].freeze
+
+  CONTROLLERS = %w[users posts comments orders products invoices sessions registrations
+    profiles settings dashboards reports notifications search tags categories].freeze
+
+  HELPERS = %w[application_helper users_helper posts_helper form_helper date_helper].freeze
+
+  # Key sections that mirror realistic Rails apps
+  SECTIONS = %w[
+    users.index users.show users.new users.edit users.form
+    posts.index posts.show posts.create posts.update posts.destroy
+    comments.index comments.new comments.form
+    orders.index orders.show orders.confirm orders.complete
+    shared.errors shared.validations shared.navigation shared.buttons shared.labels
+    mailers.welcome mailers.reset_password mailers.confirmation mailers.notification
+    admin.users.index admin.users.show admin.posts.index admin.dashboard
+    errors.not_found errors.unauthorized errors.server_error
+    auth.login auth.logout auth.register auth.forgot_password
+  ].freeze
+
+  class << self
+    def root
+      File.expand_path("../..", __dir__)
+    end
+
+    def generated_root
+      File.join(root, "benchmarks", "fixtures", "generated")
+    end
+
+    # Generate all fixtures.
+    # @param force [Boolean] regenerate even if files already exist
+    def generate_all(force: false)
+      SCALES.each_key do |scale|
+        generate(scale, force: force)
+      end
+    end
+
+    # Generate fixtures for a single scale.
+    # @param scale [:small, :medium, :large]
+    # @param force [Boolean] regenerate even if files already exist
+    # @return [String] path to the generated fixture directory
+    def generate(scale, force: false)
+      config = SCALES.fetch(scale)
+      dir = File.join(generated_root, scale.to_s)
+
+      sentinel = File.join(dir, ".generated")
+      if !force && File.exist?(sentinel)
+        return dir
+      end
+
+      FileUtils.rm_rf(dir)
+      FileUtils.mkdir_p(dir)
+
+      locales = LOCALES.first(config[:num_locales])
+      base_locale = locales.first
+      keys = generate_keys(config[:num_keys])
+
+      write_config_file(dir, locales, base_locale)
+      write_locale_files(dir, locales, base_locale, keys)
+      write_ruby_files(dir, keys, config[:num_rb_files])
+      write_erb_files(dir, keys, config[:num_erb_files], base_locale)
+
+      FileUtils.touch(sentinel)
+      dir
+    end
+
+    private
+
+    # Build a flat list of dot-separated keys distributed across realistic sections.
+    def generate_keys(count)
+      keys = []
+      per_section = [count / SECTIONS.size, 1].max
+      SECTIONS.cycle do |section|
+        break if keys.size >= count
+
+        per_section.times do |i|
+          break if keys.size >= count
+
+          keys << "#{section}.key_#{i + 1}"
+        end
+      end
+      keys.first(count)
+    end
+
+    def write_config_file(dir, locales, base_locale)
+      FileUtils.mkdir_p(File.join(dir, "config"))
+
+      config = {
+        "base_locale" => base_locale,
+        "locales" => locales,
+        "data" => {
+          "read" => ["config/locales/%{locale}.yml"],
+          "write" => ["config/locales/%{locale}.yml"]
+        },
+        "search" => {
+          "paths" => ["app/"],
+          "relative_roots" => ["app/controllers", "app/helpers", "app/views"]
+        }
+      }
+
+      File.write(File.join(dir, "config", "i18n-tasks.yml"), YAML.dump(config))
+    end
+
+    def write_locale_files(dir, locales, base_locale, keys)
+      locale_dir = File.join(dir, "config", "locales")
+      FileUtils.mkdir_p(locale_dir)
+
+      locales.each do |locale|
+        # Skip ~10% of keys for non-base locales to simulate missing translations.
+        locale_keys = if locale == base_locale
+          keys
+        else
+          keys.reject.with_index { |_, i| (i % 10).zero? }
+        end
+
+        # Mark ~10% of keys as "unused" by never referencing them in source.
+        # We track unused indices and write them in the locale files but skip them in source.
+        tree = keys_to_nested_hash(locale, locale_keys) { |key, i| "#{locale}.#{key}.value_#{i}" }
+        File.write(File.join(locale_dir, "#{locale}.yml"), YAML.dump(tree))
+      end
+    end
+
+    def keys_to_nested_hash(locale, keys)
+      root = {locale => {}}
+      keys.each_with_index do |key, i|
+        parts = key.split(".")
+        node = root[locale]
+        parts[0..-2].each do |part|
+          node[part] ||= {}
+          node = node[part]
+        end
+        node[parts.last] = block_given? ? yield(key, i) : "#{locale}.#{key}"
+      end
+      root
+    end
+
+    # Write Ruby controller/helper files referencing ~90% of keys (leaving ~10% unused).
+    def write_ruby_files(dir, keys, num_files)
+      app_dir = File.join(dir, "app")
+      FileUtils.mkdir_p(File.join(app_dir, "controllers"))
+      FileUtils.mkdir_p(File.join(app_dir, "helpers"))
+
+      # Keys that will be referenced from Ruby (skip every 10th = ~10% unused in source)
+      source_keys = keys.reject.with_index { |_, i| (i % 10).zero? }
+      keys_per_file = [source_keys.size / num_files, 1].max
+
+      num_files.times do |n|
+        file_keys = source_keys.slice(n * keys_per_file, keys_per_file) || []
+        controller_name = "#{CONTROLLERS[n % CONTROLLERS.size]}_#{n}_controller"
+        content = generate_ruby_file_content(controller_name, file_keys)
+
+        if n < num_files / 2
+          File.write(File.join(app_dir, "controllers", "#{controller_name}.rb"), content)
+        else
+          helper_name = "helper_#{n}"
+          File.write(File.join(app_dir, "helpers", "#{helper_name}.rb"), content)
+        end
+      end
+    end
+
+    def generate_ruby_file_content(class_name, keys)
+      lines = ["class #{camelize(class_name)} < ApplicationController"]
+      lines << "  def index"
+      keys.each_slice(3) do |slice|
+        case rand(4)
+        when 0
+          lines << "    I18n.t(#{slice[0].inspect})"
+          lines << "    I18n.t(#{slice[1].inspect})" if slice[1]
+        when 1
+          scope_parts = slice[0].split(".")
+          lines << "    t(#{scope_parts.last.inspect}, scope: #{scope_parts[0..-2].inspect})"
+        when 2
+          lines << "    I18n.translate(#{slice[0].inspect})"
+        else
+          lines << "    t #{slice[0].inspect}"
+          lines << "    t #{slice[1].inspect}" if slice[1]
+        end
+        lines << "    t #{slice[2].inspect}" if slice[2]
+      end
+      lines << "  end"
+
+      # Add a method with dynamic key (exercises expr_key_re)
+      if keys.any?
+        section = keys.first.split(".").first(2).join(".")
+        lines << "  def show"
+        lines << "    # dynamic key - should not count as unused"
+        lines << "    t(\"#{section}.\#{some_dynamic_value}\")"
+        lines << "  end"
+      end
+
+      lines << "end"
+      lines.join("\n")
+    end
+
+    # Write ERB view files with relative t() calls and some absolute ones.
+    def write_erb_files(dir, keys, num_files, _base_locale)
+      views_dir = File.join(dir, "app", "views")
+
+      # Use only non-"unused" keys in views to keep ~10% unused
+      source_keys = keys.reject.with_index { |_, i| (i % 10).zero? }
+      keys_per_file = [source_keys.size / [num_files, 1].max, 1].max
+
+      num_files.times do |n|
+        file_keys = source_keys.slice(n * keys_per_file, keys_per_file) || []
+        section = file_keys.first&.split(".")&.first(2)&.join("/") || "shared"
+        FileUtils.mkdir_p(File.join(views_dir, section))
+
+        content = generate_erb_file_content(file_keys)
+        File.write(File.join(views_dir, section, "view_#{n}.html.erb"), content)
+      end
+    end
+
+    def generate_erb_file_content(keys)
+      lines = ["<div>"]
+      keys.each_with_index do |key, i|
+        case i % 3
+        when 0
+          lines << "  <%= t(#{key.inspect}) %>"
+        when 1
+          # relative key - use just the last segment
+          leaf = key.split(".").last
+          lines << "  <%= t(#{".#{leaf}".inspect}) %>"
+        else
+          lines << "  <%= I18n.t(#{key.inspect}) %>"
+        end
+      end
+      lines << "</div>"
+      lines.join("\n")
+    end
+
+    def camelize(str)
+      str.split(/[_\/]/).map(&:capitalize).join
+    end
+  end
+end

--- a/benchmarks/fixtures/generator.rb
+++ b/benchmarks/fixtures/generator.rb
@@ -183,8 +183,8 @@ module BenchmarkFixtures
     def generate_ruby_file_content(class_name, keys)
       lines = ["class #{camelize(class_name)} < ApplicationController"]
       lines << "  def index"
-      keys.each_slice(3) do |slice|
-        case rand(4)
+      keys.each_slice(3).with_index do |slice, idx|
+        case idx % 4
         when 0
           lines << "    I18n.t(#{slice[0].inspect})"
           lines << "    I18n.t(#{slice[1].inspect})" if slice[1]

--- a/benchmarks/results/baseline.json
+++ b/benchmarks/results/baseline.json
@@ -1,0 +1,250 @@
+{
+  "scanning/small": {
+    "RubyScanner/parser (small)": {
+      "ips": 77.2,
+      "ips_sd": 2,
+      "microseconds": 12952.8
+    },
+    "RubyScanner/prism  (small)": {
+      "ips": 355.07,
+      "ips_sd": 17,
+      "microseconds": 2816.37
+    },
+    "ErbAstScanner      (small)": {
+      "ips": 71.72,
+      "ips_sd": 5,
+      "microseconds": 13942.38
+    },
+    "PatternScanner     (small)": {
+      "ips": 227.21,
+      "ips_sd": 14,
+      "microseconds": 4401.26
+    }
+  },
+  "scanning/medium": {
+    "RubyScanner/parser (medium)": {
+      "ips": 8.93,
+      "ips_sd": 0,
+      "microseconds": 111991.52
+    },
+    "RubyScanner/prism  (medium)": {
+      "ips": 46.36,
+      "ips_sd": 3,
+      "microseconds": 21570.39
+    },
+    "ErbAstScanner      (medium)": {
+      "ips": 7.51,
+      "ips_sd": 0,
+      "microseconds": 133124.84
+    },
+    "PatternScanner     (medium)": {
+      "ips": 24.89,
+      "ips_sd": 1,
+      "microseconds": 40172.22
+    }
+  },
+  "tree/construction": {
+    "from_key_names (200 keys)": {
+      "ips": 380.91,
+      "ips_sd": 36,
+      "microseconds": 2625.28
+    },
+    "from_key_names (2k keys)": {
+      "ips": 39.27,
+      "ips_sd": 4,
+      "microseconds": 25462.22
+    },
+    "from_key_names (8k keys)": {
+      "ips": 10.67,
+      "ips_sd": 0,
+      "microseconds": 93754.71
+    },
+    "from_nested_hash (200 keys)": {
+      "ips": 555.16,
+      "ips_sd": 17,
+      "microseconds": 1801.28
+    },
+    "from_nested_hash (2k keys)": {
+      "ips": 549.79,
+      "ips_sd": 26,
+      "microseconds": 1818.88
+    }
+  },
+  "tree/merge": {
+    "merge! (200 into 200 keys)": {
+      "ips": 2590.91,
+      "ips_sd": 78,
+      "microseconds": 385.96
+    },
+    "merge! (2k into 2k keys)": {
+      "ips": 2551.12,
+      "ips_sd": 125,
+      "microseconds": 391.98
+    }
+  },
+  "tree/traversal": {
+    "leaves (2k keys)": {
+      "ips": 11336.97,
+      "ips_sd": 339,
+      "microseconds": 88.21
+    },
+    "key_names (2k keys)": {
+      "ips": 9909.57,
+      "ips_sd": 1100,
+      "microseconds": 100.91
+    },
+    "key_names (8k keys)": {
+      "ips": 10107.61,
+      "ips_sd": 477,
+      "microseconds": 98.94
+    },
+    "select_keys (2k, match half)": {
+      "ips": 1223.67,
+      "ips_sd": 63,
+      "microseconds": 817.21
+    },
+    "nodes block iteration (2k keys)": {
+      "ips": 12809.56,
+      "ips_sd": 225,
+      "microseconds": 78.07
+    }
+  },
+  "tree/subtract": {
+    "subtract_by_key! (200 keys)": {
+      "ips": 792.82,
+      "ips_sd": 125,
+      "microseconds": 1261.32
+    },
+    "subtract_by_key! (2k keys)": {
+      "ips": 834.26,
+      "ips_sd": 31,
+      "microseconds": 1198.67
+    }
+  },
+  "data/yaml_parse": {
+    "YAML parse small  (~9KB)": {
+      "ips": 1933.54,
+      "ips_sd": 54,
+      "microseconds": 517.19
+    },
+    "YAML parse medium (~97KB)": {
+      "ips": 223.54,
+      "ips_sd": 5,
+      "microseconds": 4473.41
+    },
+    "YAML parse large  (~400KB)": {
+      "ips": 56.35,
+      "ips_sd": 2,
+      "microseconds": 17747.21
+    }
+  },
+  "data/yaml_dump": {
+    "YAML dump small  tree": {
+      "ips": 1366.38,
+      "ips_sd": 33,
+      "microseconds": 731.86
+    },
+    "YAML dump medium tree": {
+      "ips": 153.11,
+      "ips_sd": 3,
+      "microseconds": 6531.45
+    },
+    "YAML dump large  tree": {
+      "ips": 37.9,
+      "ips_sd": 1,
+      "microseconds": 26386.17
+    }
+  },
+  "data/tree_load": {
+    "from_nested_hash small": {
+      "ips": 1325.81,
+      "ips_sd": 55,
+      "microseconds": 754.26
+    },
+    "from_nested_hash medium": {
+      "ips": 190.78,
+      "ips_sd": 7,
+      "microseconds": 5241.64
+    },
+    "from_nested_hash large": {
+      "ips": 44.98,
+      "ips_sd": 2,
+      "microseconds": 22232.79
+    }
+  },
+  "data/full_load": {
+    "data['en'] load (small)": {
+      "ips": 557.68,
+      "ips_sd": 18,
+      "microseconds": 1793.15
+    },
+    "data['en'] load (medium)": {
+      "ips": 80.26,
+      "ips_sd": 2,
+      "microseconds": 12459.21
+    }
+  },
+  "end_to_end/small": {
+    "used_tree     (small)": {
+      "ips": 21.36,
+      "ips_sd": 1,
+      "microseconds": 46813.31
+    },
+    "missing_keys  (small)": {
+      "ips": 15.77,
+      "ips_sd": 1,
+      "microseconds": 63412.33
+    },
+    "unused_keys   (small)": {
+      "ips": 11.4,
+      "ips_sd": 1,
+      "microseconds": 87687.22
+    }
+  },
+  "end_to_end/medium": {
+    "used_tree     (medium)": {
+      "ips": 2.39,
+      "ips_sd": 0,
+      "microseconds": 419130.05
+    },
+    "missing_keys  (medium)": {
+      "ips": 1.14,
+      "ips_sd": 0,
+      "microseconds": 877165.79
+    },
+    "unused_keys   (medium)": {
+      "ips": 1.05,
+      "ips_sd": 0,
+      "microseconds": 948448.83
+    }
+  },
+  "end_to_end/large": {
+    "used_tree     (large)": {
+      "ips": 0.54,
+      "ips_sd": 0,
+      "microseconds": 1856802.63
+    },
+    "missing_keys  (large)": {
+      "ips": 0.18,
+      "ips_sd": 0,
+      "microseconds": 5652702.62
+    },
+    "unused_keys   (large)": {
+      "ips": 0.18,
+      "ips_sd": 0,
+      "microseconds": 5463508.26
+    }
+  },
+  "end_to_end/backend_comparison": {
+    "used_tree — parser AST (medium)": {
+      "ips": 2.4,
+      "ips_sd": 0,
+      "microseconds": 415864.89
+    },
+    "used_tree — prism (medium)": {
+      "ips": 3.1,
+      "ips_sd": 0,
+      "microseconds": 322536.32
+    }
+  }
+}

--- a/benchmarks/results/baseline.json
+++ b/benchmarks/results/baseline.json
@@ -1,124 +1,124 @@
 {
   "scanning/small": {
     "RubyScanner/parser (small)": {
-      "ips": 77.2,
-      "ips_sd": 2,
-      "microseconds": 12952.8
+      "ips": 85.14,
+      "ips_sd": 1,
+      "microseconds": 11745.33
     },
     "RubyScanner/prism  (small)": {
-      "ips": 355.07,
-      "ips_sd": 17,
-      "microseconds": 2816.37
+      "ips": 520.55,
+      "ips_sd": 5,
+      "microseconds": 1921.04
     },
     "ErbAstScanner      (small)": {
-      "ips": 71.72,
-      "ips_sd": 5,
-      "microseconds": 13942.38
+      "ips": 80.25,
+      "ips_sd": 1,
+      "microseconds": 12461.32
     },
     "PatternScanner     (small)": {
-      "ips": 227.21,
-      "ips_sd": 14,
-      "microseconds": 4401.26
+      "ips": 366.24,
+      "ips_sd": 19,
+      "microseconds": 2730.47
     }
   },
   "scanning/medium": {
     "RubyScanner/parser (medium)": {
-      "ips": 8.93,
+      "ips": 9.34,
       "ips_sd": 0,
-      "microseconds": 111991.52
+      "microseconds": 107064.63
     },
     "RubyScanner/prism  (medium)": {
-      "ips": 46.36,
-      "ips_sd": 3,
-      "microseconds": 21570.39
+      "ips": 53.15,
+      "ips_sd": 2,
+      "microseconds": 18816.42
     },
     "ErbAstScanner      (medium)": {
-      "ips": 7.51,
+      "ips": 7.82,
       "ips_sd": 0,
-      "microseconds": 133124.84
+      "microseconds": 127814.44
     },
     "PatternScanner     (medium)": {
-      "ips": 24.89,
+      "ips": 31.25,
       "ips_sd": 1,
-      "microseconds": 40172.22
+      "microseconds": 32003.1
     }
   },
   "tree/construction": {
     "from_key_names (200 keys)": {
-      "ips": 380.91,
-      "ips_sd": 36,
-      "microseconds": 2625.28
+      "ips": 336.11,
+      "ips_sd": 5,
+      "microseconds": 2975.22
     },
     "from_key_names (2k keys)": {
-      "ips": 39.27,
-      "ips_sd": 4,
-      "microseconds": 25462.22
+      "ips": 28.24,
+      "ips_sd": 2,
+      "microseconds": 35410.79
     },
     "from_key_names (8k keys)": {
-      "ips": 10.67,
+      "ips": 6.51,
       "ips_sd": 0,
-      "microseconds": 93754.71
+      "microseconds": 153567.77
     },
     "from_nested_hash (200 keys)": {
-      "ips": 555.16,
-      "ips_sd": 17,
-      "microseconds": 1801.28
+      "ips": 286.18,
+      "ips_sd": 7,
+      "microseconds": 3494.35
     },
     "from_nested_hash (2k keys)": {
-      "ips": 549.79,
-      "ips_sd": 26,
-      "microseconds": 1818.88
+      "ips": 23.43,
+      "ips_sd": 2,
+      "microseconds": 42674.17
     }
   },
   "tree/merge": {
     "merge! (200 into 200 keys)": {
-      "ips": 2590.91,
-      "ips_sd": 78,
-      "microseconds": 385.96
+      "ips": 963.35,
+      "ips_sd": 23,
+      "microseconds": 1038.04
     },
     "merge! (2k into 2k keys)": {
-      "ips": 2551.12,
-      "ips_sd": 125,
-      "microseconds": 391.98
+      "ips": 96.47,
+      "ips_sd": 3,
+      "microseconds": 10365.85
     }
   },
   "tree/traversal": {
     "leaves (2k keys)": {
-      "ips": 11336.97,
-      "ips_sd": 339,
-      "microseconds": 88.21
+      "ips": 409.96,
+      "ips_sd": 5,
+      "microseconds": 2439.29
     },
     "key_names (2k keys)": {
-      "ips": 9909.57,
-      "ips_sd": 1100,
-      "microseconds": 100.91
+      "ips": 382.42,
+      "ips_sd": 7,
+      "microseconds": 2614.92
     },
     "key_names (8k keys)": {
-      "ips": 10107.61,
-      "ips_sd": 477,
-      "microseconds": 98.94
+      "ips": 92.16,
+      "ips_sd": 4,
+      "microseconds": 10850.73
     },
     "select_keys (2k, match half)": {
-      "ips": 1223.67,
-      "ips_sd": 63,
-      "microseconds": 817.21
+      "ips": 53.54,
+      "ips_sd": 1,
+      "microseconds": 18678.8
     },
     "nodes block iteration (2k keys)": {
-      "ips": 12809.56,
-      "ips_sd": 225,
-      "microseconds": 78.07
+      "ips": 450.94,
+      "ips_sd": 5,
+      "microseconds": 2217.57
     }
   },
   "tree/subtract": {
     "subtract_by_key! (200 keys)": {
-      "ips": 792.82,
-      "ips_sd": 125,
-      "microseconds": 1261.32
+      "ips": 374.7,
+      "ips_sd": 6,
+      "microseconds": 2668.77
     },
     "subtract_by_key! (2k keys)": {
-      "ips": 834.26,
-      "ips_sd": 31,
-      "microseconds": 1198.67
+      "ips": 35.83,
+      "ips_sd": 1,
+      "microseconds": 27912.64
     }
   },
   "data/yaml_parse": {

--- a/benchmarks/run_all.rb
+++ b/benchmarks/run_all.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Runs all benchmarks and optionally saves / compares against a baseline.
+#
+# Usage:
+#   bundle exec ruby benchmarks/run_all.rb              # run everything
+#   bundle exec ruby benchmarks/run_all.rb --save       # run + save as new baseline
+#   bundle exec ruby benchmarks/run_all.rb --compare    # run + compare against baseline
+#   bundle exec ruby benchmarks/run_all.rb --only=tree  # run only tree benchmarks
+#
+# The --only flag accepts comma-separated values: tree, data, scanning, e2e
+
+bench_dir = File.dirname(__FILE__)
+
+save = ARGV.include?("--save")
+compare = ARGV.include?("--compare")
+
+only_filter = ARGV.grep(/\A--only=/).first&.sub("--only=", "")&.split(",") || []
+
+all_benches = {
+  "scanning" => File.join(bench_dir, "scanning_bench.rb"),
+  "tree" => File.join(bench_dir, "tree_bench.rb"),
+  "data" => File.join(bench_dir, "data_bench.rb"),
+  "e2e" => File.join(bench_dir, "end_to_end_bench.rb")
+}
+
+benches = if only_filter.any?
+  all_benches.slice(*only_filter)
+else
+  all_benches
+end
+
+if benches.empty?
+  warn "Unknown --only values. Available: #{all_benches.keys.join(", ")}"
+  exit 1
+end
+
+flags = []
+flags << "--save" if save
+flags << "--compare" if compare
+
+failed = false
+benches.each do |name, path|
+  puts
+  puts "━" * 70
+  puts "  Running: #{name}"
+  puts "━" * 70
+
+  result = system(RbConfig.ruby, path, *flags)
+  failed = true unless result
+end
+
+exit(failed ? 1 : 0)

--- a/benchmarks/run_all.rb
+++ b/benchmarks/run_all.rb
@@ -6,7 +6,8 @@
 # Usage:
 #   bundle exec ruby benchmarks/run_all.rb              # run everything
 #   bundle exec ruby benchmarks/run_all.rb --save       # run + save as new baseline
-#   bundle exec ruby benchmarks/run_all.rb --compare    # run + compare against baseline
+#   bundle exec ruby benchmarks/run_all.rb --compare    # run + compare against baseline (exits 1 on regression)
+#   bundle exec ruby benchmarks/run_all.rb --memory     # include memory profiles
 #   bundle exec ruby benchmarks/run_all.rb --only=tree  # run only tree benchmarks
 #
 # The --only flag accepts comma-separated values: tree, data, scanning, e2e
@@ -15,8 +16,10 @@ bench_dir = File.dirname(__FILE__)
 
 save = ARGV.include?("--save")
 compare = ARGV.include?("--compare")
+memory = ARGV.include?("--memory")
 
-only_filter = ARGV.grep(/\A--only=/).first&.sub("--only=", "")&.split(",") || []
+only_arg = ARGV.grep(/\A--only=/).first&.sub("--only=", "")
+only_filter = only_arg&.split(",") || []
 
 all_benches = {
   "scanning" => File.join(bench_dir, "scanning_bench.rb"),
@@ -25,20 +28,21 @@ all_benches = {
   "e2e" => File.join(bench_dir, "end_to_end_bench.rb")
 }
 
-benches = if only_filter.any?
-  all_benches.slice(*only_filter)
+if only_filter.any?
+  unknown = only_filter - all_benches.keys
+  if unknown.any?
+    warn "Unknown --only values: #{unknown.join(", ")}. Available: #{all_benches.keys.join(", ")}"
+    exit 1
+  end
+  benches = all_benches.slice(*only_filter)
 else
-  all_benches
-end
-
-if benches.empty?
-  warn "Unknown --only values. Available: #{all_benches.keys.join(", ")}"
-  exit 1
+  benches = all_benches
 end
 
 flags = []
 flags << "--save" if save
 flags << "--compare" if compare
+flags << "--memory" if memory
 
 failed = false
 benches.each do |name, path|

--- a/benchmarks/run_all.rb
+++ b/benchmarks/run_all.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require "rbconfig"
+
 # Runs all benchmarks and optionally saves / compares against a baseline.
 #
 # Usage:
@@ -47,9 +49,9 @@ flags << "--memory" if memory
 failed = false
 benches.each do |name, path|
   puts
-  puts "━" * 70
+  puts "-" * 70
   puts "  Running: #{name}"
-  puts "━" * 70
+  puts "-" * 70
 
   result = system(RbConfig.ruby, path, *flags)
   failed = true unless result

--- a/benchmarks/scanning_bench.rb
+++ b/benchmarks/scanning_bench.rb
@@ -7,8 +7,9 @@
 #
 # Usage:
 #   bundle exec ruby benchmarks/scanning_bench.rb
-#   bundle exec ruby benchmarks/scanning_bench.rb --save   # save as new baseline
+#   bundle exec ruby benchmarks/scanning_bench.rb --save    # save as new baseline
 #   bundle exec ruby benchmarks/scanning_bench.rb --compare # compare against baseline
+#   bundle exec ruby benchmarks/scanning_bench.rb --memory  # include memory profiles
 
 require_relative "bench_helper"
 
@@ -20,9 +21,9 @@ require "i18n/tasks/scanners/files/caching_file_reader"
 
 SAVE_RESULTS = ARGV.include?("--save")
 COMPARE_RESULTS = ARGV.include?("--compare")
+MEMORY_PROFILE = ARGV.include?("--memory")
 
-def build_scanner(scanner_class, fixture_dir, only_pattern:, **extra_config)
-  app_dir = File.join(fixture_dir, "app")
+def build_scanner(scanner_class, app_dir, only_pattern:, shared_provider:, shared_reader:, **extra_config)
   config = {
     paths: [app_dir],
     only: Array(only_pattern),
@@ -37,8 +38,8 @@ def build_scanner(scanner_class, fixture_dir, only_pattern:, **extra_config)
   }
   scanner_class.new(
     config: config,
-    file_finder_provider: I18n::Tasks::Scanners::Files::CachingFileFinderProvider.new,
-    file_reader: I18n::Tasks::Scanners::Files::CachingFileReader.new
+    file_finder_provider: shared_provider,
+    file_reader: shared_reader
   )
 end
 
@@ -46,44 +47,43 @@ all_suites = []
 
 [:small, :medium].each do |scale|
   dir = BenchmarkFixtures.generate(scale)
+  app_dir = File.join(dir, "app")
 
   BenchHelper.header("Scanning — #{scale} fixture")
+
+  # Build shared provider/reader and warm their caches so the timed block
+  # measures only parse throughput, not file-system traversal or I/O.
+  shared_provider = I18n::Tasks::Scanners::Files::CachingFileFinderProvider.new
+  shared_reader = I18n::Tasks::Scanners::Files::CachingFileReader.new
+  build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+    only_pattern: ["*.rb"], shared_provider: shared_provider,
+    shared_reader: shared_reader, prism: nil).keys
 
   suite = Benchmark.ips do |x|
     x.config(warmup: 3, time: 10)
 
     x.report("RubyScanner/parser (#{scale})") do
-      build_scanner(
-        I18n::Tasks::Scanners::RubyScanner,
-        dir,
-        only_pattern: ["*.rb"],
-        prism: nil
-      ).keys
+      build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+        only_pattern: ["*.rb"], shared_provider: shared_provider,
+        shared_reader: shared_reader, prism: nil).keys
     end
 
     x.report("RubyScanner/prism  (#{scale})") do
-      build_scanner(
-        I18n::Tasks::Scanners::RubyScanner,
-        dir,
-        only_pattern: ["*.rb"],
-        prism: "rails"
-      ).keys
+      build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+        only_pattern: ["*.rb"], shared_provider: shared_provider,
+        shared_reader: shared_reader, prism: "rails").keys
     end
 
     x.report("ErbAstScanner      (#{scale})") do
-      build_scanner(
-        I18n::Tasks::Scanners::ErbAstScanner,
-        dir,
-        only_pattern: ["*.erb"]
-      ).keys
+      build_scanner(I18n::Tasks::Scanners::ErbAstScanner, app_dir,
+        only_pattern: ["*.erb"], shared_provider: shared_provider,
+        shared_reader: shared_reader).keys
     end
 
     x.report("PatternScanner     (#{scale})") do
-      build_scanner(
-        I18n::Tasks::Scanners::PatternWithScopeScanner,
-        dir,
-        only_pattern: ["*.rb", "*.erb"]
-      ).keys
+      build_scanner(I18n::Tasks::Scanners::PatternWithScopeScanner, app_dir,
+        only_pattern: ["*.rb", "*.erb"], shared_provider: shared_provider,
+        shared_reader: shared_reader).keys
     end
 
     x.compare!
@@ -92,32 +92,35 @@ all_suites = []
   all_suites << [suite, "scanning/#{scale}"]
 end
 
-# Memory profile the full scanner suite on the medium fixture
-BenchHelper.header("Memory profile — RubyScanner/parser (medium)")
-dir = BenchmarkFixtures.generate(:medium)
+if MEMORY_PROFILE
+  dir = BenchmarkFixtures.generate(:medium)
+  app_dir = File.join(dir, "app")
+  shared_provider = I18n::Tasks::Scanners::Files::CachingFileFinderProvider.new
+  shared_reader = I18n::Tasks::Scanners::Files::CachingFileReader.new
+  # Warm caches so memory report reflects only parse allocations
+  build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+    only_pattern: ["*.rb"], shared_provider: shared_provider,
+    shared_reader: shared_reader, prism: nil).keys
 
-report = MemoryProfiler.report do
-  build_scanner(
-    I18n::Tasks::Scanners::RubyScanner,
-    dir,
-    only_pattern: ["*.rb"],
-    prism: nil
-  ).keys
+  BenchHelper.header("Memory profile — RubyScanner/parser (medium)")
+  MemoryProfiler.report do
+    build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+      only_pattern: ["*.rb"], shared_provider: shared_provider,
+      shared_reader: shared_reader, prism: nil).keys
+  end.pretty_print(scale_bytes: true, detailed_report: false)
+
+  BenchHelper.header("Memory profile — RubyScanner/prism (medium)")
+  MemoryProfiler.report do
+    build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+      only_pattern: ["*.rb"], shared_provider: shared_provider,
+      shared_reader: shared_reader, prism: "rails").keys
+  end.pretty_print(scale_bytes: true, detailed_report: false)
 end
-report.pretty_print(scale_bytes: true, detailed_report: false)
 
-BenchHelper.header("Memory profile — RubyScanner/prism (medium)")
-report = MemoryProfiler.report do
-  build_scanner(
-    I18n::Tasks::Scanners::RubyScanner,
-    dir,
-    only_pattern: ["*.rb"],
-    prism: "rails"
-  ).keys
-end
-report.pretty_print(scale_bytes: true, detailed_report: false)
-
+passed = true
 all_suites.each do |(suite, label)|
   BenchHelper.save_results(suite, label) if SAVE_RESULTS
-  BenchHelper.compare_baseline(suite, label) if COMPARE_RESULTS
+  passed = false if COMPARE_RESULTS && !BenchHelper.compare_baseline(suite, label)
 end
+
+exit(1) if COMPARE_RESULTS && !passed

--- a/benchmarks/scanning_bench.rb
+++ b/benchmarks/scanning_bench.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+# Benchmarks for the source-code scanning hot path.
+#
+# Measures per-scanner throughput (IPS) for Ruby (parser AST and Prism backends)
+# and ERB scanning across fixture scales.
+#
+# Usage:
+#   bundle exec ruby benchmarks/scanning_bench.rb
+#   bundle exec ruby benchmarks/scanning_bench.rb --save   # save as new baseline
+#   bundle exec ruby benchmarks/scanning_bench.rb --compare # compare against baseline
+
+require_relative "bench_helper"
+
+require "i18n/tasks/scanners/ruby_scanner"
+require "i18n/tasks/scanners/erb_ast_scanner"
+require "i18n/tasks/scanners/pattern_with_scope_scanner"
+require "i18n/tasks/scanners/files/caching_file_finder_provider"
+require "i18n/tasks/scanners/files/caching_file_reader"
+
+SAVE_RESULTS = ARGV.include?("--save")
+COMPARE_RESULTS = ARGV.include?("--compare")
+
+def build_scanner(scanner_class, fixture_dir, only_pattern:, **extra_config)
+  app_dir = File.join(fixture_dir, "app")
+  config = {
+    paths: [app_dir],
+    only: Array(only_pattern),
+    exclude: [],
+    relative_roots: [
+      File.join(app_dir, "controllers"),
+      File.join(app_dir, "helpers"),
+      File.join(app_dir, "views")
+    ],
+    relative_exclude_method_name_paths: [],
+    **extra_config
+  }
+  scanner_class.new(
+    config: config,
+    file_finder_provider: I18n::Tasks::Scanners::Files::CachingFileFinderProvider.new,
+    file_reader: I18n::Tasks::Scanners::Files::CachingFileReader.new
+  )
+end
+
+all_suites = []
+
+[:small, :medium].each do |scale|
+  dir = BenchmarkFixtures.generate(scale)
+
+  BenchHelper.header("Scanning — #{scale} fixture")
+
+  suite = Benchmark.ips do |x|
+    x.config(warmup: 3, time: 10)
+
+    x.report("RubyScanner/parser (#{scale})") do
+      build_scanner(
+        I18n::Tasks::Scanners::RubyScanner,
+        dir,
+        only_pattern: ["*.rb"],
+        prism: nil
+      ).keys
+    end
+
+    x.report("RubyScanner/prism  (#{scale})") do
+      build_scanner(
+        I18n::Tasks::Scanners::RubyScanner,
+        dir,
+        only_pattern: ["*.rb"],
+        prism: "rails"
+      ).keys
+    end
+
+    x.report("ErbAstScanner      (#{scale})") do
+      build_scanner(
+        I18n::Tasks::Scanners::ErbAstScanner,
+        dir,
+        only_pattern: ["*.erb"]
+      ).keys
+    end
+
+    x.report("PatternScanner     (#{scale})") do
+      build_scanner(
+        I18n::Tasks::Scanners::PatternWithScopeScanner,
+        dir,
+        only_pattern: ["*.rb", "*.erb"]
+      ).keys
+    end
+
+    x.compare!
+  end
+
+  all_suites << [suite, "scanning/#{scale}"]
+end
+
+# Memory profile the full scanner suite on the medium fixture
+BenchHelper.header("Memory profile — RubyScanner/parser (medium)")
+dir = BenchmarkFixtures.generate(:medium)
+
+report = MemoryProfiler.report do
+  build_scanner(
+    I18n::Tasks::Scanners::RubyScanner,
+    dir,
+    only_pattern: ["*.rb"],
+    prism: nil
+  ).keys
+end
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+BenchHelper.header("Memory profile — RubyScanner/prism (medium)")
+report = MemoryProfiler.report do
+  build_scanner(
+    I18n::Tasks::Scanners::RubyScanner,
+    dir,
+    only_pattern: ["*.rb"],
+    prism: "rails"
+  ).keys
+end
+report.pretty_print(scale_bytes: true, detailed_report: false)
+
+all_suites.each do |(suite, label)|
+  BenchHelper.save_results(suite, label) if SAVE_RESULTS
+  BenchHelper.compare_baseline(suite, label) if COMPARE_RESULTS
+end

--- a/benchmarks/scanning_bench.rb
+++ b/benchmarks/scanning_bench.rb
@@ -51,13 +51,22 @@ all_suites = []
 
   BenchHelper.header("Scanning — #{scale} fixture")
 
-  # Build shared provider/reader and warm their caches so the timed block
-  # measures only parse throughput, not file-system traversal or I/O.
+  # Build shared provider/reader and warm their caches for every pattern used below,
+  # so the timed block measures only parse throughput, not file-system traversal or I/O.
   shared_provider = I18n::Tasks::Scanners::Files::CachingFileFinderProvider.new
   shared_reader = I18n::Tasks::Scanners::Files::CachingFileReader.new
   build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
     only_pattern: ["*.rb"], shared_provider: shared_provider,
     shared_reader: shared_reader, prism: nil).keys
+  build_scanner(I18n::Tasks::Scanners::RubyScanner, app_dir,
+    only_pattern: ["*.rb"], shared_provider: shared_provider,
+    shared_reader: shared_reader, prism: "rails").keys
+  build_scanner(I18n::Tasks::Scanners::ErbAstScanner, app_dir,
+    only_pattern: ["*.erb"], shared_provider: shared_provider,
+    shared_reader: shared_reader).keys
+  build_scanner(I18n::Tasks::Scanners::PatternWithScopeScanner, app_dir,
+    only_pattern: ["*.rb", "*.erb"], shared_provider: shared_provider,
+    shared_reader: shared_reader).keys
 
   suite = Benchmark.ips do |x|
     x.config(warmup: 3, time: 10)

--- a/benchmarks/tree_bench.rb
+++ b/benchmarks/tree_bench.rb
@@ -9,6 +9,7 @@
 #   bundle exec ruby benchmarks/tree_bench.rb
 #   bundle exec ruby benchmarks/tree_bench.rb --save
 #   bundle exec ruby benchmarks/tree_bench.rb --compare
+#   bundle exec ruby benchmarks/tree_bench.rb --memory  # include memory profiles
 
 require_relative "bench_helper"
 
@@ -17,6 +18,7 @@ require "i18n/tasks/data/tree/node"
 
 SAVE_RESULTS = ARGV.include?("--save")
 COMPARE_RESULTS = ARGV.include?("--compare")
+MEMORY_PROFILE = ARGV.include?("--memory")
 
 Node = I18n::Tasks::Data::Tree::Node
 Siblings = I18n::Tasks::Data::Tree::Siblings
@@ -27,17 +29,10 @@ Siblings = I18n::Tasks::Data::Tree::Siblings
 
 def flat_keys(count)
   sections = %w[users posts comments orders products admin auth errors shared mailers]
-  keys = []
-  sections.cycle do |s|
-    break if keys.size >= count
-
-    10.times do |i|
-      break if keys.size >= count
-
-      keys << "#{s}.section_#{i / 5}.item_#{i}.label"
-    end
+  Array.new(count) do |i|
+    section = sections[i % sections.size]
+    "#{section}.group_#{i / sections.size}.item_#{i}.label"
   end
-  keys.first(count)
 end
 
 def build_siblings(key_count)
@@ -180,17 +175,20 @@ subtract_suite = Benchmark.ips do |x|
 end
 
 # ---------------------------------------------------------------------------
-# Memory profiles
+# Memory profiles (opt-in via --memory)
 # ---------------------------------------------------------------------------
 
-BenchHelper.header("Memory — from_key_names (2k keys)")
-MemoryProfiler.report { Siblings.from_key_names(MEDIUM_KEYS) }
-  .pretty_print(scale_bytes: true, detailed_report: false)
+if MEMORY_PROFILE
+  BenchHelper.header("Memory — from_key_names (2k keys)")
+  MemoryProfiler.report { Siblings.from_key_names(MEDIUM_KEYS) }
+    .pretty_print(scale_bytes: true, detailed_report: false)
 
-BenchHelper.header("Memory — from_nested_hash (2k keys)")
-MemoryProfiler.report { Siblings.from_nested_hash(MEDIUM_HASH) }
-  .pretty_print(scale_bytes: true, detailed_report: false)
+  BenchHelper.header("Memory — from_nested_hash (2k keys)")
+  MemoryProfiler.report { Siblings.from_nested_hash(MEDIUM_HASH) }
+    .pretty_print(scale_bytes: true, detailed_report: false)
+end
 
+passed = true
 if SAVE_RESULTS
   BenchHelper.save_results(construction_suite, "tree/construction")
   BenchHelper.save_results(merge_suite, "tree/merge")
@@ -199,8 +197,10 @@ if SAVE_RESULTS
 end
 
 if COMPARE_RESULTS
-  BenchHelper.compare_baseline(construction_suite, "tree/construction")
-  BenchHelper.compare_baseline(merge_suite, "tree/merge")
-  BenchHelper.compare_baseline(traversal_suite, "tree/traversal")
-  BenchHelper.compare_baseline(subtract_suite, "tree/subtract")
+  passed = false unless BenchHelper.compare_baseline(construction_suite, "tree/construction")
+  passed = false unless BenchHelper.compare_baseline(merge_suite, "tree/merge")
+  passed = false unless BenchHelper.compare_baseline(traversal_suite, "tree/traversal")
+  passed = false unless BenchHelper.compare_baseline(subtract_suite, "tree/subtract")
 end
+
+exit(1) if COMPARE_RESULTS && !passed

--- a/benchmarks/tree_bench.rb
+++ b/benchmarks/tree_bench.rb
@@ -1,0 +1,206 @@
+# frozen_string_literal: true
+
+# Micro-benchmarks for the tree data structure operations.
+#
+# These isolate pure tree performance with no I/O, making them useful for
+# detecting regressions in the tree algorithms themselves.
+#
+# Usage:
+#   bundle exec ruby benchmarks/tree_bench.rb
+#   bundle exec ruby benchmarks/tree_bench.rb --save
+#   bundle exec ruby benchmarks/tree_bench.rb --compare
+
+require_relative "bench_helper"
+
+require "i18n/tasks/data/tree/siblings"
+require "i18n/tasks/data/tree/node"
+
+SAVE_RESULTS = ARGV.include?("--save")
+COMPARE_RESULTS = ARGV.include?("--compare")
+
+Node = I18n::Tasks::Data::Tree::Node
+Siblings = I18n::Tasks::Data::Tree::Siblings
+
+# ---------------------------------------------------------------------------
+# Helpers to build in-memory trees of various sizes without touching disk
+# ---------------------------------------------------------------------------
+
+def flat_keys(count)
+  sections = %w[users posts comments orders products admin auth errors shared mailers]
+  keys = []
+  sections.cycle do |s|
+    break if keys.size >= count
+
+    10.times do |i|
+      break if keys.size >= count
+
+      keys << "#{s}.section_#{i / 5}.item_#{i}.label"
+    end
+  end
+  keys.first(count)
+end
+
+def build_siblings(key_count)
+  Siblings.from_key_names(flat_keys(key_count))
+end
+
+def build_nested_hash(key_count, locale = "en")
+  keys = flat_keys(key_count)
+  hash = {locale => {}}
+  keys.each_with_index do |key, i|
+    parts = key.split(".")
+    node = hash[locale]
+    parts[0..-2].each { |p|
+      node[p] ||= {}
+      node = node[p]
+    }
+    node[parts.last] = "value_#{i}"
+  end
+  hash
+end
+
+# Pre-build fixtures so allocation is not counted
+SMALL_KEYS = flat_keys(200).freeze
+MEDIUM_KEYS = flat_keys(2_000).freeze
+LARGE_KEYS = flat_keys(8_000).freeze
+
+SMALL_HASH = build_nested_hash(200).freeze
+MEDIUM_HASH = build_nested_hash(2_000).freeze
+
+SMALL_TREE = build_siblings(200).freeze
+MEDIUM_TREE = build_siblings(2_000).freeze
+LARGE_TREE = build_siblings(8_000).freeze
+
+SMALL_TREE_B = build_siblings(200).freeze
+MEDIUM_TREE_B = build_siblings(2_000).freeze
+
+# ---------------------------------------------------------------------------
+# Construction benchmarks
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Tree construction")
+
+construction_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("from_key_names (200 keys)") do
+    Siblings.from_key_names(SMALL_KEYS)
+  end
+
+  x.report("from_key_names (2k keys)") do
+    Siblings.from_key_names(MEDIUM_KEYS)
+  end
+
+  x.report("from_key_names (8k keys)") do
+    Siblings.from_key_names(LARGE_KEYS)
+  end
+
+  x.report("from_nested_hash (200 keys)") do
+    Siblings.from_nested_hash(SMALL_HASH)
+  end
+
+  x.report("from_nested_hash (2k keys)") do
+    Siblings.from_nested_hash(MEDIUM_HASH)
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Merge benchmarks
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Tree merge")
+
+merge_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("merge! (200 into 200 keys)") do
+    SMALL_TREE.derive.merge!(SMALL_TREE_B)
+  end
+
+  x.report("merge! (2k into 2k keys)") do
+    MEDIUM_TREE.derive.merge!(MEDIUM_TREE_B)
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Traversal benchmarks
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Tree traversal")
+
+traversal_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("leaves (2k keys)") do
+    MEDIUM_TREE.leaves.to_a
+  end
+
+  x.report("key_names (2k keys)") do
+    MEDIUM_TREE.key_names
+  end
+
+  x.report("key_names (8k keys)") do
+    LARGE_TREE.key_names
+  end
+
+  x.report("select_keys (2k, match half)") do
+    i = 0
+    MEDIUM_TREE.select_keys { |_key, _node| (i += 1).odd? }
+  end
+
+  x.report("nodes block iteration (2k keys)") do
+    MEDIUM_TREE.nodes.to_a
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# subtract_by_key! benchmark
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Tree subtract")
+
+subtract_suite = Benchmark.ips do |x|
+  x.config(warmup: 3, time: 10)
+
+  x.report("subtract_by_key! (200 keys)") do
+    SMALL_TREE.derive.subtract_by_key!(SMALL_TREE_B)
+  end
+
+  x.report("subtract_by_key! (2k keys)") do
+    MEDIUM_TREE.derive.subtract_by_key!(MEDIUM_TREE_B)
+  end
+
+  x.compare!
+end
+
+# ---------------------------------------------------------------------------
+# Memory profiles
+# ---------------------------------------------------------------------------
+
+BenchHelper.header("Memory — from_key_names (2k keys)")
+MemoryProfiler.report { Siblings.from_key_names(MEDIUM_KEYS) }
+  .pretty_print(scale_bytes: true, detailed_report: false)
+
+BenchHelper.header("Memory — from_nested_hash (2k keys)")
+MemoryProfiler.report { Siblings.from_nested_hash(MEDIUM_HASH) }
+  .pretty_print(scale_bytes: true, detailed_report: false)
+
+if SAVE_RESULTS
+  BenchHelper.save_results(construction_suite, "tree/construction")
+  BenchHelper.save_results(merge_suite, "tree/merge")
+  BenchHelper.save_results(traversal_suite, "tree/traversal")
+  BenchHelper.save_results(subtract_suite, "tree/subtract")
+end
+
+if COMPARE_RESULTS
+  BenchHelper.compare_baseline(construction_suite, "tree/construction")
+  BenchHelper.compare_baseline(merge_suite, "tree/merge")
+  BenchHelper.compare_baseline(traversal_suite, "tree/traversal")
+  BenchHelper.compare_baseline(subtract_suite, "tree/subtract")
+end

--- a/benchmarks/tree_bench.rb
+++ b/benchmarks/tree_bench.rb
@@ -20,7 +20,6 @@ SAVE_RESULTS = ARGV.include?("--save")
 COMPARE_RESULTS = ARGV.include?("--compare")
 MEMORY_PROFILE = ARGV.include?("--memory")
 
-Node = I18n::Tasks::Data::Tree::Node
 Siblings = I18n::Tasks::Data::Tree::Siblings
 
 # ---------------------------------------------------------------------------
@@ -45,10 +44,10 @@ def build_nested_hash(key_count, locale = "en")
   keys.each_with_index do |key, i|
     parts = key.split(".")
     node = hash[locale]
-    parts[0..-2].each { |p|
+    parts[0..-2].each do |p|
       node[p] ||= {}
       node = node[p]
-    }
+    end
     node[parts.last] = "value_#{i}"
   end
   hash


### PR DESCRIPTION
Introduces a four-layer benchmark suite to detect performance
regressions and improvements across the gem's critical paths.

## Structure

benchmarks/
  fixtures/generator.rb       — synthetic app fixture generator
  bench_helper.rb             — shared setup, context helpers, save/compare
  scanning_bench.rb           — per-scanner IPS (parser AST vs Prism vs ERB vs Pattern)
  tree_bench.rb               — tree construction, merge, traversal, subtract
  data_bench.rb               — YAML parse/dump, hash→tree, BaseTask data load
  end_to_end_bench.rb         — full missing_keys / unused_keys / used_tree pipeline
  run_all.rb                  — orchestrator with --save / --compare / --only flags
  results/baseline.json       — committed baseline for regression detection

## Fixture generator

Produces small / medium / large synthetic codebases:
- small:  200 keys, 15 .rb + 15 .erb, 2 locales
- medium: 2000 keys, 100 .rb + 100 .erb, 5 locales
- large:  8000 keys, 300 .rb + 300 .erb, 8 locales

~10% of keys are missing from non-base locales; ~10% defined but
never referenced in source — mirrors realistic Rails apps.

## Usage

  bundle exec ruby benchmarks/run_all.rb             # run all
  bundle exec ruby benchmarks/run_all.rb --save      # update baseline
  bundle exec ruby benchmarks/run_all.rb --compare   # detect regressions
  bundle exec ruby benchmarks/run_all.rb --only=e2e  # single suite

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
