### PR TITLE
Fix crash when human_attribute_name is called with interpolated string argument

### DIFF
--- a/lib/i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb
+++ b/lib/i18n/tasks/scanners/ast_matchers/rails_model_matcher.rb
@@ -20,6 +20,10 @@ module I18n::Tasks::Scanners::AstMatchers
 
       value = children[2]
 
+      # Only process static string/symbol arguments; dynamic args (dstr/dsym) cannot be
+      # statically resolved and would produce a bogus key (e.g. "activerecord.attributes.product.").
+      return unless value && %i[str sym].include?(value.type)
+
       model_name = underscore(receiver.to_a.last)
       attribute = extract_string(value)
       # Convert dots to slashes to match Rails' human_attribute_name behavior

--- a/lib/i18n/tasks/scanners/prism_scanners/arguments_visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/arguments_visitor.rb
@@ -39,6 +39,20 @@ module I18n::Tasks::Scanners::PrismScanners
       node.content
     end
 
+    # Interpolated nodes (e.g. `Product.human_attribute_name("status.#{status}")`) contain dynamic content that cannot
+    # be statically resolved. Return nil so process_arguments compacts them away and the call is skipped.
+    def visit_interpolated_string_node(_node)
+      nil
+    end
+
+    def visit_interpolated_symbol_node(_node)
+      nil
+    end
+
+    def visit_interpolated_x_string_node(_node)
+      nil
+    end
+
     def visit_array_node(node)
       node.child_nodes.map { |child| visit(child) }
     end

--- a/spec/fixtures/used_keys/a.rb
+++ b/spec/fixtures/used_keys/a.rb
@@ -16,6 +16,8 @@ class A
     User.model_name.human(count: 2)
     # Slash notation for nested attributes (issue #702)
     Product.human_attribute_name("status.active")
+    # Dynamic argument - cannot be statically resolved, should be skipped without error
+    Product.human_attribute_name("status.#{status}")
     # Cannot infer the type
     human_attribute_name(:name)
     model_name.human(count: 2)

--- a/spec/used_keys_ruby_prism_spec.rb
+++ b/spec/used_keys_ruby_prism_spec.rb
@@ -180,6 +180,11 @@ RSpec.describe "UsedKeysRubyPrism" do
       )
     end
 
+    it "does not crash or produce a key for human_attribute_name with interpolated string argument" do
+      expect { leaves }.not_to raise_error
+      expect(leaves.keys.count { |k| k.include?("product/status") }).to eq(1)
+    end
+
     it "verifies key 'service.what'" do
       expect_node_key_data(
         leaves["service.what"],

--- a/spec/used_keys_ruby_spec.rb
+++ b/spec/used_keys_ruby_spec.rb
@@ -169,6 +169,11 @@ RSpec.describe "UsedKeysRuby" do
     )
   end
 
+  it "does not produce a key for human_attribute_name with interpolated string argument" do
+    leaves = leaves_to_hash(task.used_tree.leaves.to_a)
+    expect(leaves.keys.count { |k| k.include?("product/status") }).to eq(1)
+  end
+
   describe "strict = false" do
     let(:strict) { false }
 
@@ -177,6 +182,11 @@ RSpec.describe "UsedKeysRuby" do
       expect(used_keys.size).to eq(1)
       leaves = used_keys.leaves.to_a
       expect(leaves.size).to(eq(7))
+    end
+
+    it "does not produce a key for human_attribute_name with interpolated string argument" do
+      leaves = leaves_to_hash(task.used_tree.leaves.to_a)
+      expect(leaves.keys.count { |k| k.include?("product/status") }).to eq(1)
     end
   end
 


### PR DESCRIPTION
## Problem

When using `prism: "rails"` scanner config, calling `Model.human_attribute_name` with an interpolated string argument crashes with a `TypeError`:

```
TypeError: no implicit conversion of Array into String
```

**Root cause:** `ArgumentsVisitor` has no handler for `InterpolatedStringNode`. Prism::Visitor's default `visit_child_nodes` returns the raw child node array, which propagates as the `attribute_name` value. In `rails_handle_human_attribute_name`, the array is then used in string concatenation, causing the crash.

The same issue exists in the whitequark AST path: `RailsModelMatcher` did not guard against non-static attribute arguments, producing bogus keys like `activerecord.attributes.model.#<Prism::StringNode:...>` in the missing keys report.

## Fix

1. **`ArgumentsVisitor`**: add explicit `nil`-returning handlers for `InterpolatedStringNode`, `InterpolatedSymbolNode`, and `InterpolatedXStringNode`. The `nil` is compacted away by `process_arguments`, causing the call to be correctly skipped as unresolvable.

2. **`RailsModelMatcher`**: guard against non-`str`/`sym` attribute arguments before attempting key construction.

## Test

Added `Product.human_attribute_name("status.#{status}")` to the shared fixture and a dedicated spec asserting no crash and no spurious key produced.