### PR TITLE
Prism scanner records unscoped key when scope is an unresolvable method call

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/arguments_visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/arguments_visitor.rb
@@ -31,6 +31,12 @@ module I18n::Tasks::Scanners::PrismScanners
       nil
     end
 
+    # Shorthand hash syntax (e.g. `scope:` as shorthand for `scope: scope`) wraps
+    # the implicit value in an ImplicitNode — delegate to the inner node.
+    def visit_implicit_node(node)
+      visit(node.value)
+    end
+
     def visit_symbol_node(node)
       node.value
     end

--- a/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/nodes.rb
@@ -165,7 +165,7 @@ module I18n::Tasks::Scanners::PrismScanners
 
     def scope
       return nil if @options.nil?
-      return nil unless @options["scope"]
+      return nil unless @options.key?("scope")
 
       scope_value = @options["scope"]
       scope_array = Array(scope_value)

--- a/spec/fixtures/used_keys/a.rb
+++ b/spec/fixtures/used_keys/a.rb
@@ -32,4 +32,14 @@ class A
   def issue444
     t('ignore_array', scope: [:ignore, SCOPE_CONSTANT])
   end
+
+  def scope
+    'some.scope'
+  end
+
+  def test_dynamic_scope
+    # Dynamic scope - cannot be statically resolved, should be skipped
+    t('shorthand_scope_key', scope:)
+    t('chained_scope_key', scope: f.object.report.model_name.collection)
+  end
 end

--- a/spec/used_keys_ruby_prism_spec.rb
+++ b/spec/used_keys_ruby_prism_spec.rb
@@ -185,6 +185,11 @@ RSpec.describe "UsedKeysRubyPrism" do
       expect(leaves.keys.count { |k| k.include?("product/status") }).to eq(1)
     end
 
+    it "does not produce a key for t with unresolvable method call scope" do
+      expect(leaves.keys).not_to include("shorthand_scope_key")
+      expect(leaves.keys).not_to include("chained_scope_key")
+    end
+
     it "verifies key 'service.what'" do
       expect_node_key_data(
         leaves["service.what"],


### PR DESCRIPTION
When scope: is passed as a method call, ArgumentsVisitor#visit_call_node returns nil. TranslationCall#scope used a truthiness check on the options value, so nil was treated as "no scope provided" — recording the bare key and producing a false missing-key report.

Fix by using Hash#key? to distinguish an absent scope from an unresolvable one. Also add visit_implicit_node to ArgumentsVisitor to handle the implicit hash value node explicitly rather than relying on default fallthrough.