### PR TITLE
[Prism Scanner] fix wrongfully reported missing keys in nested models

### DIFF
--- a/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
@@ -303,7 +303,7 @@ module I18n::Tasks::Scanners::PrismScanners
 
       # We need to check for `node.receiver` since node is the `human` call
       model_name = if current_class.present? && rails_model_method_called_on_current_class?(node.receiver)
-        current_class.path.flatten.map!(&:underscore).join(".")
+        current_class.path.flatten.map!(&:underscore).join("/")
       elsif node.receiver&.receiver&.type == :constant_read_node
         node.receiver&.receiver&.name&.to_s&.underscore
       end
@@ -364,13 +364,21 @@ module I18n::Tasks::Scanners::PrismScanners
         [
           :activerecord,
           :attributes,
-          current_class.path.flatten.map!(&:underscore).join(".")
+          current_class.path.flatten.map!(&:underscore).join("/")
         ].join(".") + separator + attribute_name
       elsif node.receiver&.name.present?
+        # For namespaced models (Foo::Bar), Rails uses "/" as separator in i18n keys
+        # (e.g. activerecord.attributes.foo/bar.name). ConstantPathNode#full_name
+        # returns "Foo::Bar"; replace "::" with "/" to match that convention.
+        model_key = if node.receiver.is_a?(Prism::ConstantPathNode)
+          node.receiver.full_name.gsub(/^::/, "").gsub("::", "/").underscore
+        else
+          node.receiver.name.to_s.underscore
+        end
         [
           :activerecord,
           :attributes,
-          node.receiver.name.to_s.underscore
+          model_key
         ].join(".") + separator + attribute_name
       else
         return

--- a/spec/missing_keys_spec.rb
+++ b/spec/missing_keys_spec.rb
@@ -96,4 +96,94 @@ RSpec.describe "MissingKeys" do
       expect(missing.leaves.to_a).to be_empty
     end
   end
+
+  describe "Nested ActiveRecord model with Prism scanner (rails)" do
+    let(:task) { I18n::Tasks::BaseTask.new }
+
+    around do |ex|
+      TestCodebase.setup(
+        "config/i18n-tasks.yml" => {
+          base_locale: "en",
+          locales: %w[en],
+          search: {paths: %w[app/], prism: "rails"}
+        }.to_yaml,
+        "app/models/foo/bar.rb" => <<~RUBY,
+          module Foo
+            class Bar < ApplicationRecord
+              attr_accessor :name
+            end
+          end
+
+          Foo::Bar.human_attribute_name(:name)
+        RUBY
+        "config/locales/en.yml" => {
+          "en" => {
+            "activerecord" => {
+              "attributes" => {"foo/bar" => {"name" => "Name"}}
+            }
+          }
+        }.to_yaml
+      )
+      TestCodebase.in_test_app_dir { ex.call }
+      TestCodebase.teardown
+    end
+
+    # The scanner should resolve Foo::Bar to the key "foo/bar" (Rails convention:
+    # Model.model_name.i18n_key uses "/" as namespace separator). If it only uses
+    # the leaf constant "Bar", it generates activerecord.attributes.bar.name —
+    # which is used but absent from the locale and would be reported as missing.
+    it "does not report bar.name as missing (correctly resolves Foo::Bar to activerecord.attributes.foo/bar)" do
+      missing_keys = task.missing_keys(locales: ["en"])
+
+      expect(missing_keys["en.activerecord.attributes.bar.name"]).to be_nil
+    end
+  end
+
+  describe "module-nested model calling human_attribute_name without explicit receiver" do
+    let(:task) { I18n::Tasks::BaseTask.new }
+
+    around do |ex|
+      TestCodebase.setup(
+        "config/i18n-tasks.yml" => {
+          base_locale: "en",
+          locales: %w[en],
+          search: {paths: %w[app/], prism: "rails"}
+        }.to_yaml,
+        "app/models/foo/bar.rb" => <<~RUBY,
+          module Foo
+            class Bar < ApplicationRecord
+              def label
+                human_attribute_name(:name)
+              end
+            end
+          end
+        RUBY
+        "config/locales/en.yml" => {
+          "en" => {
+            "activerecord" => {
+              "attributes" => {"foo/bar" => {"name" => "Name"}}
+            }
+          }
+        }.to_yaml
+      )
+      TestCodebase.in_test_app_dir { ex.call }
+      TestCodebase.teardown
+    end
+
+    # Without explicit receiver, current_class.path is used to build the model key.
+    # It must join namespace segments with "/" (foo/bar) not "." (foo.bar),
+    # otherwise Rails' actual key activerecord.attributes.foo/bar.name is not found
+    # and reported as falsely missing.
+    it "does not report foo/bar.name as missing when human_attribute_name is called without receiver" do
+      missing_keys = task.missing_keys(locales: ["en"])
+
+      expect(missing_keys["en.activerecord.attributes.foo/bar.name"]).to be_nil
+    end
+
+    it "does not generate a dot-separated key activerecord.attributes.foo.bar.name" do
+      missing_keys = task.missing_keys(locales: ["en"])
+
+      expect(missing_keys["en.activerecord.attributes.foo.bar.name"]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Prism scanner only respects the last part of nested model names. But for [namespaced models](https://guides.rubyonrails.org/active_record_basics.html#creating-namespaced-models) Rails generates keys with the full model name, joined by slashes (`foo/bar` for a `class Foo::Bar`).

When investigating [my issue with ActiveModels that use AttrJsonModel](https://github.com/glebm/i18n-tasks/issues/738) I found this to be an issue also affecting `ActiveRecord` based models when they are namespaced.