### PR TITLE
[Feature request] Plugin API

### DIFF
--- a/lib/i18n/tasks/base_task.rb
+++ b/lib/i18n/tasks/base_task.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "i18n/tasks/command_error"
+require "i18n/tasks/plugins"
 require "i18n/tasks/split_key"
 require "i18n/tasks/key_pattern_matching"
 require "i18n/tasks/logging"

--- a/lib/i18n/tasks/configuration.rb
+++ b/lib/i18n/tasks/configuration.rb
@@ -47,6 +47,15 @@ module I18n::Tasks::Configuration # rubocop:disable Metrics/ModuleLength
   def config=(conf)
     @config = file_config.deep_merge(conf)
     @config_sections = {}
+    @plugin_registry = nil
+  end
+
+  def plugin_registry
+    @plugin_registry ||= begin
+      registry = I18n::Tasks::Plugins::Registry.new
+      I18n::Tasks::Plugins::Loader.load(config[:plugins], registry)
+      registry
+    end
   end
 
   # data config

--- a/lib/i18n/tasks/data.rb
+++ b/lib/i18n/tasks/data.rb
@@ -15,6 +15,7 @@ module I18n::Tasks
         data_config = (config[:data] || {}).deep_symbolize_keys
         data_config[:base_locale] = base_locale
         data_config[:locales] = config[:locales]
+        data_config[:plugin_registry] = plugin_registry
         adapter_class = data_config[:adapter].presence || data_config[:class].presence || DATA_DEFAULTS[:adapter]
         adapter_class = adapter_class.to_s
         adapter_class = "I18n::Tasks::Data::FileSystem" if adapter_class == "file_system"

--- a/lib/i18n/tasks/data/file_formats.rb
+++ b/lib/i18n/tasks/data/file_formats.rb
@@ -37,7 +37,8 @@ module I18n
 
         # @return [Hash]
         def load_file(path)
-          adapter_parse read_file(path), self.class.adapter_name_for_path(path)
+          data = adapter_parse read_file(path), self.class.adapter_name_for_path(path)
+          @plugin_registry ? @plugin_registry.reduce(:load_locale, data, path: path) : data
         rescue CommandError => e
           raise(e.class, "#{e.message} (file: #{path})")
         end
@@ -48,6 +49,7 @@ module I18n
         end
 
         def write_tree(path, tree, sort = true)
+          tree = @plugin_registry.reduce(:store_locale, tree, path: path) if @plugin_registry
           hash = tree.to_hash(sort)
           adapter = self.class.adapter_name_for_path(path)
           content = adapter_dump(hash, adapter)
@@ -61,6 +63,7 @@ module I18n
         def normalized?(path, tree)
           return false unless File.file?(path)
 
+          tree = @plugin_registry.reduce(:store_locale, tree, path: path) if @plugin_registry
           read_file(path) == adapter_dump(tree.to_hash(true), self.class.adapter_name_for_path(path))
         end
 

--- a/lib/i18n/tasks/data/file_system_base.rb
+++ b/lib/i18n/tasks/data/file_system_base.rb
@@ -23,7 +23,8 @@ module I18n::Tasks
       }.freeze
 
       def initialize(config = {})
-        self.config = config.except(:base_locale, :locales)
+        @plugin_registry = config[:plugin_registry]
+        self.config = config.except(:base_locale, :locales, :plugin_registry)
         self.config[:sort] = !config[:keep_order]
         @base_locale = config[:base_locale]
         locales = config[:locales].presence

--- a/lib/i18n/tasks/plugins.rb
+++ b/lib/i18n/tasks/plugins.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "i18n/tasks/plugins/registry"
+require "i18n/tasks/plugins/loader"
+require "i18n/tasks/plugins/base_plugin"

--- a/lib/i18n/tasks/plugins/base_plugin.rb
+++ b/lib/i18n/tasks/plugins/base_plugin.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module I18n
+  module Tasks
+    module Plugins
+      # Base class for i18n-tasks plugins.  Subclasses get a class-level DSL for
+      # declaring hooks and scanner configuration; the +register+ instance method
+      # is provided and does not need to be overridden.
+      #
+      # Usage:
+      #
+      #   class MyPlugin < I18n::Tasks::Plugins::BasePlugin
+      #     def initialize(config = {})
+      #       @root = config[:root]
+      #     end
+      #
+      #     register_hook :load_locale do |data, path:|
+      #       # `self` is the plugin instance — @root and private methods are accessible
+      #       next data unless path.start_with?(@root)
+      #       transform(data)
+      #     end
+      #   end
+      #
+      class BasePlugin
+        # Declare a hook callback executed in the context of the plugin instance.
+        # Multiple calls stack; hooks run in declaration order.
+        #
+        # @param name [Symbol] hook name (e.g. :load_locale)
+        def self.register_hook(name, &block)
+          _plugin_hooks << [name, block]
+        end
+
+        # Declare an additional scanner to add to the search config.
+        # @param class_name [String]
+        # @param options [Hash]
+        def self.add_scanner(class_name, **options)
+          _plugin_scanners_to_add << [class_name, options]
+        end
+
+        # Declare a glob pattern to exclude from an existing scanner.
+        # @param scanner_class [String]
+        # @param pattern [String]
+        def self.exclude_from_scanner(scanner_class, pattern)
+          _plugin_scanner_excludes[scanner_class] << pattern
+        end
+
+        def self._plugin_hooks
+          @_plugin_hooks ||= []
+        end
+
+        def self._plugin_scanners_to_add
+          @_plugin_scanners_to_add ||= []
+        end
+
+        def self._plugin_scanner_excludes
+          @_plugin_scanner_excludes ||= Hash.new { |h, k| h[k] = [] }
+        end
+
+        # Wires all declared hooks and scanner config into +registry+.
+        # Called by the plugin loader — subclasses do not need to override this.
+        def register(hooks)
+          self.class._plugin_hooks.each do |(name, block)|
+            hooks.on(name) { |*args, **kwargs| instance_exec(*args, **kwargs, &block) }
+          end
+
+          self.class._plugin_scanners_to_add.each do |(class_name, options)|
+            hooks.add_scanner(class_name, **options)
+          end
+
+          self.class._plugin_scanner_excludes.each do |scanner_class, patterns|
+            patterns.each { |pattern| hooks.exclude_from_scanner(scanner_class, pattern) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/tasks/plugins/loader.rb
+++ b/lib/i18n/tasks/plugins/loader.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module I18n
+  module Tasks
+    module Plugins
+      module Loader
+        NAMESPACE = "I18n::Tasks::Plugins"
+
+        # Load and register all plugins declared in +plugins_config+.
+        #
+        # Each key in +plugins_config+ is either a shorthand that maps to
+        # +I18n::Tasks::Plugins::<CamelisedKey>+, or an arbitrary label when the
+        # config entry carries an explicit +class:+ key.  An optional +require:+
+        # key forces a specific require path; without it the path is derived from
+        # the class name (Bundler-loaded gems need no explicit require).
+        #
+        # @param plugins_config [Hash, nil] the :plugins section from i18n-tasks.yml
+        # @param registry [Registry]
+        def self.load(plugins_config, registry)
+          return unless plugins_config.present?
+
+          plugins_config.each do |key, raw_config|
+            config = (raw_config || {}).with_indifferent_access
+            class_name = config.delete(:class).presence || key_to_class_name(key)
+            req_path = config.delete(:require)
+
+            ensure_loaded(class_name, req_path)
+            ActiveSupport::Inflector.constantize(class_name).new(config).register(registry)
+          end
+        end
+
+        def self.key_to_class_name(key)
+          "#{NAMESPACE}::#{ActiveSupport::Inflector.camelize(key.to_s)}"
+        end
+        private_class_method :key_to_class_name
+
+        def self.ensure_loaded(class_name, req_path)
+          if req_path
+            require req_path
+          elsif !class_defined?(class_name)
+            require class_name_to_path(class_name)
+          end
+        end
+        private_class_method :ensure_loaded
+
+        def self.class_defined?(class_name)
+          ActiveSupport::Inflector.constantize(class_name)
+          true
+        rescue NameError
+          false
+        end
+        private_class_method :class_defined?
+
+        def self.class_name_to_path(class_name)
+          ActiveSupport::Inflector.underscore(class_name)
+        end
+        private_class_method :class_name_to_path
+      end
+    end
+  end
+end

--- a/lib/i18n/tasks/plugins/rails_model.rb
+++ b/lib/i18n/tasks/plugins/rails_model.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+require "set"
+require_relative "base_plugin"
+
+module I18n
+  module Tasks
+    module Plugins
+      # Plugin that fixes two limitations of the Prism scanner's Rails model localization support:
+      #
+      # 1. STI fallback: when a child class (e.g. Car < Vehicle < ApplicationRecord) calls
+      #    `human_attribute_name` or `model_name.human`, Rails falls back up the inheritance chain
+      #    if a key is not found for the child. This plugin adds the ancestor keys as candidate_keys
+      #    so i18n-tasks doesn't report parent-class translations as unused.
+      #
+      # 2. ActiveModel namespace: classes that include ActiveModel::Model (or a module that
+      #    transitively includes it) but are not ActiveRecord models must use `activemodel.*`
+      #    keys, not `activerecord.*`. This plugin corrects the namespace when it detects the
+      #    class is an ActiveModel-only class.
+      #
+      # Configuration in i18n-tasks.yml:
+      #
+      #   plugins:
+      #     rails_model:
+      #       models_paths:
+      #         - app/models/**/*.rb
+      #       active_model_includes:   # optional — extend the default [ActiveModel::Model]
+      #         - AttrJson::Model      # any module that transitively includes ActiveModel::Model
+      #
+      class RailsModel < BasePlugin
+        AR_ROOTS = %w[ApplicationRecord ActiveRecord::Base].freeze
+
+        # Patterns that unconditionally mark a class as ActiveModel-only.
+        # `extend ActiveModel::Translation` is the standard Rails way to add
+        # human_attribute_name / model_name support to a plain Ruby class.
+        AM_DEFAULT_PATTERNS = [
+          /\binclude\s+ActiveModel::Model\b/,
+          /\bextend\s+ActiveModel::Translation\b/,
+        ].freeze
+
+        def initialize(config = {})
+          paths          = config.fetch(:models_paths, ["app/models/**/*.rb"])
+          extra_includes = Array(config.fetch(:active_model_includes, []))
+          @am_pattern    = Regexp.union(
+            AM_DEFAULT_PATTERNS +
+            extra_includes.map { |mod| /\binclude\s+#{Regexp.escape(mod)}\b/ }
+          )
+          @model_index = build_model_index(Array(paths))
+        end
+
+        # Hook: :resolve_model_key
+        # Receives: { key:, candidate_keys: } plus model_constant_name:, call_type:, attribute_name:
+        # Returns: potentially modified { key:, candidate_keys: }
+        register_hook :resolve_model_key do |result, model_constant_name:, call_type:, attribute_name: nil, **|
+          info = @model_index[model_constant_name]
+          next result unless info
+
+          key = result[:key]
+          candidate_keys = result[:candidate_keys].dup
+
+          if info[:active_model] && key.start_with?("activerecord.")
+            key = key.sub("activerecord.", "activemodel.")
+            candidate_keys = candidate_keys.map { |k| k.sub("activerecord.", "activemodel.") }
+          end
+
+          if info[:active_record]
+            sti_chain(model_constant_name).each do |parent_name|
+              parent_key = ActiveSupport::Inflector.underscore(parent_name)
+              candidate_keys << case call_type
+              when :human_attribute_name
+                separator = attribute_name&.include?(".") ? "/" : "."
+                "activerecord.attributes.#{parent_key}#{separator}#{attribute_name}"
+              when :model_name
+                "activerecord.models.#{parent_key}"
+              end
+            end
+            candidate_keys.compact!
+          end
+
+          {key: key, candidate_keys: candidate_keys}
+        end
+
+        private
+
+        def build_model_index(path_patterns)
+          index = {}
+          Dir.glob(path_patterns).each do |file_path|
+            index_file(file_path, index)
+          end
+          resolve_active_record!(index)
+          resolve_active_model!(index)
+          index
+        end
+
+        def index_file(file_path, index)
+          content = File.read(file_path)
+          content.scan(/^\s*class\s+(\w+)(?:\s*<\s*(\S+))?/) do |class_name, parent_name|
+            qualified  = qualified_class_name(content, class_name)
+            is_ar_root = AR_ROOTS.include?(parent_name)
+            is_am      = @am_pattern.match?(content) &&
+                         !content.match?(/\b(?:ApplicationRecord|ActiveRecord::Base)\b/)
+            index[qualified] = {
+              parent:        parent_name&.split("::")&.last,
+              active_model:  is_am,
+              ar_root:       is_ar_root,
+              active_record: false # resolved below
+            }
+          end
+        end
+
+        # Derive the fully qualified Ruby constant name by collecting module
+        # declarations that appear before the class definition in the file.
+        # Works for both top-level classes ("OperationalRack") and module-nested
+        # classes ("AttrJsonModels::LocationCapacity::Power").
+        def qualified_class_name(content, class_name)
+          modules = []
+          content.each_line do |line|
+            break if line.match?(/^\s*class\s+#{Regexp.escape(class_name)}\b/)
+            modules << Regexp.last_match(1) if line.match(/^\s*module\s+(\S+)/)
+          end
+          ([*modules, class_name]).join("::")
+        end
+
+        def resolve_active_record!(index)
+          index.each_key { |name| index[name][:active_record] = ar_ancestor?(name, index, Set.new) }
+        end
+
+        def resolve_active_model!(index)
+          index.each_key { |name| index[name][:active_model] ||= am_ancestor?(name, index, Set.new) }
+        end
+
+        def am_ancestor?(name, index, visited)
+          return false if visited.include?(name)
+          visited << name
+          info = index[name]
+          return false unless info
+          return true if info[:active_model]
+
+          am_ancestor?(info[:parent].to_s, index, visited)
+        end
+
+        def ar_ancestor?(name, index, visited)
+          return false if visited.include?(name)
+          visited << name
+          info = index[name]
+          return false unless info
+          return true if info[:ar_root]
+
+          ar_ancestor?(info[:parent].to_s, index, visited)
+        end
+
+        def sti_chain(class_name)
+          chain = []
+          visited = Set.new([class_name])
+          current = @model_index.dig(class_name, :parent)
+          while current && !visited.include?(current)
+            info = @model_index[current]
+            break unless info
+            break if AR_ROOTS.include?(current)  # skip framework base classes
+
+            chain << current
+            visited << current
+            break if info[:ar_root]  # include this domain class, then stop
+
+            current = info[:parent]
+          end
+          chain
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/tasks/plugins/registry.rb
+++ b/lib/i18n/tasks/plugins/registry.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module I18n
+  module Tasks
+    module Plugins
+      class Registry
+        attr_reader :scanners_to_add, :scanner_excludes
+
+        def initialize
+          @hooks = Hash.new { |h, k| h[k] = [] }
+          @scanners_to_add = []
+          @scanner_excludes = Hash.new { |h, k| h[k] = [] }
+        end
+
+        # @param hook_name [Symbol]
+        # @return [self]
+        def on(hook_name, &block)
+          @hooks[hook_name] << block
+          self
+        end
+
+        # Declare an additional scanner.
+        # @param class_name [String] fully qualified scanner class name
+        # @param options [Hash] scanner options (only:, exclude:, etc.)
+        # @return [self]
+        def add_scanner(class_name, **options)
+          @scanners_to_add << [class_name, options]
+          self
+        end
+
+        # Declare a glob pattern to exclude from an existing scanner.
+        # @param scanner_class [String] fully qualified scanner class name
+        # @param pattern [String]
+        # @return [self]
+        def exclude_from_scanner(scanner_class, pattern)
+          @scanner_excludes[scanner_class] << pattern
+          self
+        end
+
+        # Reduce-chain hook: each registered block transforms the primary value.
+        # The block receives +value+ as first positional arg plus +context+ as keyword args,
+        # and should return the transformed value (returning nil keeps the previous value).
+        # @param hook_name [Symbol]
+        # @param value the primary value to transform
+        # @param context [Hash] additional read-only context
+        # @return the final transformed value, or +value+ if no hooks are registered
+        def reduce(hook_name, value, **context)
+          @hooks[hook_name].reduce(value) { |v, hook| hook.call(v, **context) || v }
+        end
+
+        # Collect-chain hook: each block contributes additional items.
+        # @param hook_name [Symbol]
+        # @param context [Hash] keyword args passed to each block
+        # @return [Array] flat array of all collected items
+        def collect(hook_name, **context)
+          @hooks[hook_name].flat_map { |hook| hook.call(**context) }
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
+++ b/lib/i18n/tasks/scanners/prism_scanners/visitor.rb
@@ -16,7 +16,7 @@ module I18n::Tasks::Scanners::PrismScanners
 
     attr_reader(:calls, :current_module, :current_class, :current_method, :root, :processed_magic_comment_ids)
 
-    def initialize(rails: false, file_path: nil)
+    def initialize(rails: false, file_path: nil, plugin_registry: nil)
       @calls = []
 
       @current_module = nil
@@ -26,6 +26,7 @@ module I18n::Tasks::Scanners::PrismScanners
       @processed_magic_comment_ids = []
 
       @rails = rails
+      @plugin_registry = plugin_registry
 
       # Needs to have () because the Prism::Visitor has no arguments
       super()
@@ -320,14 +321,32 @@ module I18n::Tasks::Scanners::PrismScanners
         "other"
       end
 
+      model_constant_name = if current_class.present? && rails_model_method_called_on_current_class?(node.receiver)
+        current_class.path.flatten.join("::")
+      else
+        node.receiver&.receiver&.name&.to_s
+      end
+
+      key = [:activerecord, :models, model_name, count_key].join(".")
+      candidate_keys = [[:activerecord, :models, model_name].join(".")]
+
+      if @plugin_registry && model_constant_name
+        hook_result = @plugin_registry.reduce(
+          :resolve_model_key,
+          {key: key, candidate_keys: candidate_keys},
+          model_constant_name: model_constant_name,
+          call_type: :model_name
+        )
+        key = hook_result[:key]
+        candidate_keys = hook_result[:candidate_keys]
+      end
+
       parent.add_translation_call(
         TranslationCall.new(
           node: node,
           receiver: nil,
-          key: [:activerecord, :models, model_name, count_key].join("."),
-          candidate_keys: [
-            [:activerecord, :models, model_name].join(".")
-          ],
+          key: key,
+          candidate_keys: candidate_keys,
           parent: parent,
           options: kwargs
         )
@@ -376,11 +395,33 @@ module I18n::Tasks::Scanners::PrismScanners
         return
       end
 
+      model_constant_name = if current_class.present? && rails_model_method_called_on_current_class?(node)
+        current_class.path.flatten.join("::")
+      elsif node.receiver.is_a?(Prism::ConstantPathNode)
+        node.receiver.full_name.to_s.delete_prefix("::")
+      else
+        node.receiver&.name&.to_s
+      end
+
+      candidate_keys = attribute_name.include?(".") ? [] : Array([:attributes, attribute_name].join("."))
+
+      if @plugin_registry && model_constant_name
+        hook_result = @plugin_registry.reduce(
+          :resolve_model_key,
+          {key: key, candidate_keys: candidate_keys},
+          model_constant_name: model_constant_name,
+          call_type: :human_attribute_name,
+          attribute_name: attribute_name
+        )
+        key = hook_result[:key]
+        candidate_keys = hook_result[:candidate_keys]
+      end
+
       parent.add_translation_call(
         TranslationCall.new(
           node: node,
           key: key,
-          candidate_keys: attribute_name.include?(".") ? [] : Array([:attributes, attribute_name].join(".")),
+          candidate_keys: candidate_keys,
           receiver: nil,
           parent: parent,
           options: {}

--- a/lib/i18n/tasks/scanners/relative_keys.rb
+++ b/lib/i18n/tasks/scanners/relative_keys.rb
@@ -21,11 +21,17 @@ module I18n
                                "Set search.relative_roots in config/i18n-tasks.yml (currently #{roots.inspect})")
           normalized_path.sub!(root, "")
 
-          if (exclude_method_name_paths || []).map { |p| expand_path(p) }.include?(root)
+          result = if (exclude_method_name_paths || []).map { |p| expand_path(p) }.include?(root)
             "#{prefix(normalized_path)}#{key}"
           else
             "#{prefix(normalized_path, calling_method: calling_method)}#{key}"
           end
+
+          registry = config[:plugin_registry]
+          return result unless registry
+
+          registry.reduce(:resolve_relative_key, result,
+            path: path, raw_key: key, calling_method: calling_method)
         end
 
         private

--- a/lib/i18n/tasks/scanners/results/occurrence.rb
+++ b/lib/i18n/tasks/scanners/results/occurrence.rb
@@ -29,7 +29,7 @@ module I18n::Tasks
         attr_accessor :raw_key
 
         # @return [Array<String>, nil] candidate keys that may be used at runtime
-        attr_reader :candidate_keys
+        attr_accessor :candidate_keys
 
         # @param path        [String]
         # @param pos         [Integer]

--- a/lib/i18n/tasks/scanners/ruby_scanner.rb
+++ b/lib/i18n/tasks/scanners/ruby_scanner.rb
@@ -183,7 +183,8 @@ module I18n::Tasks::Scanners
 
       visitor = I18n::Tasks::Scanners::PrismScanners::Visitor.new(
         rails: config[:prism] != "ruby",
-        file_path: path
+        file_path: path,
+        plugin_registry: config[:plugin_registry]
       )
       parsed.accept(visitor)
 
@@ -221,7 +222,7 @@ module I18n::Tasks::Scanners
         end
       end
 
-      occurrences
+      post_process_prism_occurrences(occurrences, path)
     end
 
     def skip_prism_comment?(comments)
@@ -229,6 +230,21 @@ module I18n::Tasks::Scanners
         content =
           comment.respond_to?(:slice) ? comment.slice : comment.location.slice
         content.include?(MAGIC_COMMENT_SKIP_PRISM)
+      end
+    end
+
+    def post_process_prism_occurrences(occurrences, path)
+      registry = config[:plugin_registry]
+      return occurrences unless registry
+
+      occurrences.map! do |(key, occurrence)|
+        processed_key = registry.reduce(:resolve_relative_key, key,
+          path: path, raw_key: occurrence.raw_key,
+          calling_method: nil)
+        # candidate_keys on the Occurrence were set from the Prism-assembled key.
+        # If the hook changed the key, those candidates are stale — replace them.
+        occurrence.candidate_keys = [processed_key] if processed_key != key
+        [processed_key, occurrence]
       end
     end
   end

--- a/lib/i18n/tasks/used_keys.rb
+++ b/lib/i18n/tasks/used_keys.rb
@@ -69,6 +69,7 @@ module I18n::Tasks
     def scanner(strict: nil)
       (@scanner ||= {})[strict?(strict)] ||= begin
         shared_options = search_config.dup
+        shared_options[:plugin_registry] = plugin_registry
         shared_options.delete(:scanners)
         shared_options[:strict] = strict unless strict.nil?
         log_verbose "Scanners: "
@@ -103,7 +104,9 @@ module I18n::Tasks
           warn_deprecated "search.include is now search.only"
           conf[:only] = conf.delete(:include)
         end
-        merge_scanner_configs(SEARCH_DEFAULTS, conf).freeze
+        result = merge_scanner_configs(SEARCH_DEFAULTS, conf)
+        apply_plugin_scanner_config(result)
+        result.freeze
       end
     end
 
@@ -133,6 +136,25 @@ module I18n::Tasks
     end
 
     private
+
+    # Merge add_scanner / exclude_from_scanner declarations from the plugin registry
+    # into the already-merged scanner config before it is frozen.
+    def apply_plugin_scanner_config(conf)
+      registry = plugin_registry
+      return if registry.scanner_excludes.empty? && registry.scanners_to_add.empty?
+
+      # Dup each scanner entry so we don't mutate frozen hashes from SEARCH_DEFAULTS
+      scanners = conf[:scanners].map { |(klass, opts)| [klass, (opts || {}).dup] }
+
+      registry.scanner_excludes.each do |scanner_class, patterns|
+        entry = scanners.find { |(klass, _)| klass == scanner_class }
+        next unless entry
+
+        entry[1][:exclude] = Array(entry[1][:exclude]) + patterns
+      end
+
+      conf[:scanners] = scanners + registry.scanners_to_add
+    end
 
     # @param strict [Boolean, nil]
     # @return [Boolean]

--- a/spec/fixtures/used_keys/app/models/application_record.rb
+++ b/spec/fixtures/used_keys/app/models/application_record.rb
@@ -1,0 +1,2 @@
+class ApplicationRecord < ActiveRecord::Base
+end

--- a/spec/fixtures/used_keys/app/models/car.rb
+++ b/spec/fixtures/used_keys/app/models/car.rb
@@ -1,0 +1,2 @@
+class Car < Vehicle
+end

--- a/spec/fixtures/used_keys/app/models/vehicle.rb
+++ b/spec/fixtures/used_keys/app/models/vehicle.rb
@@ -1,0 +1,2 @@
+class Vehicle < ApplicationRecord
+end

--- a/spec/fixtures/used_keys/sti_models.rb
+++ b/spec/fixtures/used_keys/sti_models.rb
@@ -1,0 +1,7 @@
+class A
+  def what
+    # STI: Car < Vehicle < ApplicationRecord
+    Car.human_attribute_name(:make)
+    Car.model_name.human(count: 2)
+  end
+end

--- a/spec/plugins/rails_model_spec.rb
+++ b/spec/plugins/rails_model_spec.rb
@@ -1,0 +1,338 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+require "i18n/tasks/plugins/registry"
+require "i18n/tasks/plugins/rails_model"
+
+RSpec.describe I18n::Tasks::Plugins::RailsModel do
+  let(:tmp_dir) { Dir.mktmpdir("rails_model_spec") }
+
+  after { FileUtils.remove_entry(tmp_dir) }
+
+  # --------------------------------------------------------------------------
+  # Helpers
+  # --------------------------------------------------------------------------
+
+  def write_model(filename, content)
+    path = File.join(tmp_dir, filename)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  def build_plugin
+    described_class.new(models_paths: ["#{tmp_dir}/**/*.rb"])
+  end
+
+  def resolve_key(plugin, key:, candidate_keys: [], **context)
+    registry = I18n::Tasks::Plugins::Registry.new
+    plugin.register(registry)
+    registry.reduce(
+      :resolve_model_key,
+      {key: key, candidate_keys: candidate_keys},
+      **context
+    )
+  end
+
+  # --------------------------------------------------------------------------
+  # Fixture model files
+  # --------------------------------------------------------------------------
+
+  before do
+    write_model("application_record.rb", <<~RUBY)
+      class ApplicationRecord < ActiveRecord::Base
+      end
+    RUBY
+
+    write_model("location.rb", <<~RUBY)
+      class Location < ApplicationRecord
+      end
+    RUBY
+
+    write_model("base_rack.rb", <<~RUBY)
+      class BaseRack < Location
+      end
+    RUBY
+
+    write_model("operational_rack.rb", <<~RUBY)
+      class OperationalRack < BaseRack
+      end
+    RUBY
+
+    write_model("history_entry.rb", <<~RUBY)
+      class HistoryEntry
+        include ActiveModel::Model
+      end
+    RUBY
+
+    write_model("remote/printer.rb", <<~RUBY)
+      module Remote
+        class Printer < Flexirest::Base
+          extend ActiveModel::Translation
+        end
+      end
+    RUBY
+
+    write_model("application_form.rb", <<~RUBY)
+      class ApplicationForm
+        include ActiveModel::Model
+      end
+    RUBY
+
+    write_model("devices_form.rb", <<~RUBY)
+      class DevicesForm < ApplicationForm
+      end
+    RUBY
+
+    write_model("devices/transition_form.rb", <<~RUBY)
+      module Devices
+        class TransitionForm < DevicesForm
+        end
+      end
+    RUBY
+  end
+
+  # --------------------------------------------------------------------------
+  # Model index building
+  # --------------------------------------------------------------------------
+
+  describe "model index" do
+    subject(:index) { build_plugin.instance_variable_get(:@model_index) }
+
+    it "recognises the first-level AR class (direct ApplicationRecord child)" do
+      expect(index["Location"][:active_record]).to be(true)
+      expect(index["Location"][:ar_root]).to be(true)
+      expect(index["BaseRack"][:ar_root]).to be(false)
+      expect(index["OperationalRack"][:ar_root]).to be(false)
+    end
+
+    it "recognises AR ancestry transitively" do
+      expect(index["OperationalRack"][:active_record]).to be(true)
+      expect(index["BaseRack"][:active_record]).to be(true)
+    end
+
+    it "recognises ActiveModel-only class (include ActiveModel::Model)" do
+      expect(index["HistoryEntry"][:active_model]).to be(true)
+      expect(index["HistoryEntry"][:active_record]).to be(false)
+    end
+
+    it "recognises ActiveModel via extend ActiveModel::Translation" do
+      expect(index["Remote::Printer"][:active_model]).to be(true)
+      expect(index["Remote::Printer"][:active_record]).to be(false)
+    end
+
+    it "records the immediate parent name" do
+      expect(index["OperationalRack"][:parent]).to eq("BaseRack")
+      expect(index["BaseRack"][:parent]).to eq("Location")
+      expect(index["Location"][:parent]).to eq("ApplicationRecord")
+    end
+
+    it "recognises ActiveModel transitively through the inheritance chain" do
+      expect(index["ApplicationForm"][:active_model]).to be(true)
+      expect(index["DevicesForm"][:active_model]).to be(true)
+      expect(index["Devices::TransitionForm"][:active_model]).to be(true)
+      expect(index["Devices::TransitionForm"][:active_record]).to be(false)
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # STI fallback — human_attribute_name
+  # --------------------------------------------------------------------------
+
+  describe "STI candidate keys for human_attribute_name" do
+    it "adds intermediate parent keys" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.attributes.operational_rack.name",
+        candidate_keys: ["attributes.name"],
+        model_constant_name: "OperationalRack",
+        call_type: :human_attribute_name,
+        attribute_name: "name"
+      )
+      expect(result[:key]).to eq("activerecord.attributes.operational_rack.name")
+      expect(result[:candidate_keys]).to include(
+        "attributes.name",
+        "activerecord.attributes.base_rack.name",
+        "activerecord.attributes.location.name"
+      )
+    end
+
+    it "uses slash separator for dotted attribute names" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.attributes.operational_rack/status.active",
+        candidate_keys: [],
+        model_constant_name: "OperationalRack",
+        call_type: :human_attribute_name,
+        attribute_name: "status.active"
+      )
+      expect(result[:candidate_keys]).to include(
+        "activerecord.attributes.base_rack/status.active",
+        "activerecord.attributes.location/status.active"
+      )
+    end
+
+    it "is a no-op for a direct AR root class (no parents to add)" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.attributes.location.name",
+        candidate_keys: ["attributes.name"],
+        model_constant_name: "Location",
+        call_type: :human_attribute_name,
+        attribute_name: "name"
+      )
+      expect(result[:candidate_keys]).to eq(["attributes.name"])
+    end
+
+    it "is a no-op for unknown classes" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.attributes.unknown.name",
+        candidate_keys: ["attributes.name"],
+        model_constant_name: "Unknown",
+        call_type: :human_attribute_name,
+        attribute_name: "name"
+      )
+      expect(result).to eq(
+        key: "activerecord.attributes.unknown.name",
+        candidate_keys: ["attributes.name"]
+      )
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # STI fallback — model_name
+  # --------------------------------------------------------------------------
+
+  describe "STI candidate keys for model_name" do
+    it "adds parent model keys as candidates" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.models.operational_rack.one",
+        candidate_keys: ["activerecord.models.operational_rack"],
+        model_constant_name: "OperationalRack",
+        call_type: :model_name
+      )
+      expect(result[:key]).to eq("activerecord.models.operational_rack.one")
+      expect(result[:candidate_keys]).to include(
+        "activerecord.models.operational_rack",
+        "activerecord.models.base_rack",
+        "activerecord.models.location"
+      )
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # ActiveModel namespace correction
+  # --------------------------------------------------------------------------
+
+  describe "ActiveModel namespace" do
+    it "replaces activerecord with activemodel for ActiveModel-only classes" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.attributes.history_entry.message",
+        candidate_keys: ["attributes.message"],
+        model_constant_name: "HistoryEntry",
+        call_type: :human_attribute_name,
+        attribute_name: "message"
+      )
+      expect(result[:key]).to eq("activemodel.attributes.history_entry.message")
+      expect(result[:candidate_keys]).to include("attributes.message")
+      expect(result[:candidate_keys]).not_to include(match(/activerecord/))
+    end
+
+    it "replaces namespace in candidate_keys too" do
+      result = resolve_key(
+        build_plugin,
+        key: "activerecord.models.history_entry.one",
+        candidate_keys: ["activerecord.models.history_entry"],
+        model_constant_name: "HistoryEntry",
+        call_type: :model_name
+      )
+      expect(result[:key]).to eq("activemodel.models.history_entry.one")
+      expect(result[:candidate_keys]).to eq(["activemodel.models.history_entry"])
+    end
+  end
+
+  # --------------------------------------------------------------------------
+  # active_model_includes config — transitive ActiveModel detection
+  # --------------------------------------------------------------------------
+
+  describe "active_model_includes config" do
+    before do
+      write_model("json_record.rb", <<~RUBY)
+        class JsonRecord
+          include AttrJson::Model
+        end
+      RUBY
+
+      write_model("attr_json_models/location_capacity/power.rb", <<~RUBY)
+        module AttrJsonModels
+          module LocationCapacity
+            class Power
+              include AttrJson::Model
+            end
+          end
+        end
+      RUBY
+    end
+
+    it "does not detect the class as ActiveModel without the config" do
+      plugin = described_class.new(models_paths: ["#{tmp_dir}/**/*.rb"])
+      index = plugin.instance_variable_get(:@model_index)
+      expect(index["JsonRecord"][:active_model]).to be(false)
+    end
+
+    it "detects the class as ActiveModel when the module is listed in active_model_includes" do
+      plugin = described_class.new(
+        models_paths: ["#{tmp_dir}/**/*.rb"],
+        active_model_includes: ["AttrJson::Model"]
+      )
+      index = plugin.instance_variable_get(:@model_index)
+      expect(index["JsonRecord"][:active_model]).to be(true)
+    end
+
+    it "indexes module-wrapped classes only under their fully qualified name" do
+      plugin = described_class.new(
+        models_paths: ["#{tmp_dir}/**/*.rb"],
+        active_model_includes: ["AttrJson::Model"]
+      )
+      index = plugin.instance_variable_get(:@model_index)
+      expect(index["Power"]).to be_nil
+      expect(index["AttrJsonModels::LocationCapacity::Power"]).not_to be_nil
+      expect(index["AttrJsonModels::LocationCapacity::Power"][:active_model]).to be(true)
+    end
+
+    it "corrects the namespace when called with a fully qualified constant name" do
+      plugin = described_class.new(
+        models_paths: ["#{tmp_dir}/**/*.rb"],
+        active_model_includes: ["AttrJson::Model"]
+      )
+      result = resolve_key(
+        plugin,
+        key: "activerecord.attributes.attr_json_models/location_capacity/power.value",
+        candidate_keys: [],
+        model_constant_name: "AttrJsonModels::LocationCapacity::Power",
+        call_type: :human_attribute_name,
+        attribute_name: "value"
+      )
+      expect(result[:key]).to eq("activemodel.attributes.attr_json_models/location_capacity/power.value")
+    end
+
+    it "corrects the namespace for the class when configured" do
+      plugin = described_class.new(
+        models_paths: ["#{tmp_dir}/**/*.rb"],
+        active_model_includes: ["AttrJson::Model"]
+      )
+      result = resolve_key(
+        plugin,
+        key: "activerecord.attributes.json_record.value",
+        candidate_keys: ["attributes.value"],
+        model_constant_name: "JsonRecord",
+        call_type: :human_attribute_name,
+        attribute_name: "value"
+      )
+      expect(result[:key]).to eq("activemodel.attributes.json_record.value")
+    end
+  end
+end

--- a/spec/prism_scanner_spec.rb
+++ b/spec/prism_scanner_spec.rb
@@ -404,6 +404,24 @@ RSpec.describe "PrismScanner" do
       )
     end
 
+    it "rails - human_attribute_name inside module-nested class uses slash as namespace separator" do
+      source = <<~RUBY
+        module Foo
+          class Bar < ApplicationRecord
+            def label
+              human_attribute_name(:name)
+              self.class.human_attribute_name(:name)
+            end
+          end
+        end
+      RUBY
+
+      occurrences = process_string("app/models/foo/bar.rb", source)
+
+      expect(occurrences.map(&:first)).to include("activerecord.attributes.foo/bar.name")
+      expect(occurrences.map(&:first)).not_to include("activerecord.attributes.foo.bar.name")
+    end
+
     it "rails - model methods - inside the class" do
       source = <<~RUBY
         class Event < ApplicationRecord

--- a/spec/used_keys_ruby_prism_spec.rb
+++ b/spec/used_keys_ruby_prism_spec.rb
@@ -390,4 +390,39 @@ RSpec.describe "UsedKeysRubyPrism" do
       ])
     end
   end
+
+  describe ":resolve_model_key hook" do
+    require "i18n/tasks/plugins/rails_model"
+
+    let(:paths) { %w[sti_models.rb] }
+
+    before do
+      task.config[:plugins] = {
+        rails_model: {models_paths: ["app/models/**/*.rb"]}
+      }
+    end
+
+    it "adds STI parent candidate_keys for human_attribute_name" do
+      leaves = leaves_to_hash(task.used_tree.leaves.to_a)
+      occurrence = leaves["activerecord.attributes.car.make"].data[:occurrences].first
+      expect(occurrence.candidate_keys).to include(
+        "activerecord.attributes.car.make",
+        "activerecord.attributes.vehicle.make"
+      )
+    end
+
+    it "does not overwrite the primary key" do
+      leaves = leaves_to_hash(task.used_tree.leaves.to_a)
+      expect(leaves).to have_key("activerecord.attributes.car.make")
+    end
+
+    it "adds STI parent candidate_keys for model_name.human" do
+      leaves = leaves_to_hash(task.used_tree.leaves.to_a)
+      occurrence = leaves["activerecord.models.car.other"].data[:occurrences].first
+      expect(occurrence.candidate_keys).to include(
+        "activerecord.models.car",
+        "activerecord.models.vehicle"
+      )
+    end
+  end
 end


### PR DESCRIPTION
When adapting my [ViewComponent` plugin](https://rubygems.org/gems/i18n_tasks-plugin-view_component) to the Prism scanner, I found I'd had to replicate the code that makes the necessary adjustments for keys found in templates in [sidecar directories](https://viewcomponent.org/guide/templates.html#subdirectory).

As I already [suggested](https://github.com/glebm/i18n-tasks/issues/738#issuecomment-4517031627) a plugin API for I18nTasks, I fired up Claude Code to build a prototype.

I don't think this is already ready for merging. I present this as a request for discussion how such a plugin API for I18n-Tasks could be built (and if it is something you would consider at all).

This also includes a demo plugin that fixes [my issue with STI model resolution](https://github.com/glebm/i18n-tasks/issues/739).